### PR TITLE
refactor: prepare code for NUnit 1001

### DIFF
--- a/Expressif.Testing/Functions/Numeric/NumericFunctionsTest.cs
+++ b/Expressif.Testing/Functions/Numeric/NumericFunctionsTest.cs
@@ -143,7 +143,7 @@ namespace Expressif.Testing.Functions.Numeric
         [TestCase("(null)", null)]
         [TestCase("(empty)", null)]
         [TestCase("(blank)", null)]
-        public void Oppose_Valid(object value, decimal? expected)
+        public void Oppose_Valid(object? value, decimal? expected)
             => Assert.That(new Oppose().Evaluate(value), Is.EqualTo(expected));
     }
 }

--- a/Expressif.Testing/Functions/Numeric/PowerRootFunctionsTest.cs
+++ b/Expressif.Testing/Functions/Numeric/PowerRootFunctionsTest.cs
@@ -19,7 +19,7 @@ namespace Expressif.Testing.Functions.Numeric
         [TestCase("(null)", null)]
         [TestCase("(empty)", null)]
         [TestCase("(blank)", null)]
-        public void SquarePower_Valid(object value, decimal? expected)
+        public void SquarePower_Valid(object? value, decimal? expected)
             => Assert.That(new SquarePower().Evaluate(value), Is.EqualTo(expected));
 
         [Test]
@@ -29,7 +29,7 @@ namespace Expressif.Testing.Functions.Numeric
         [TestCase(2, 8)]
         [TestCase(-2, -8)]
         [TestCase(null, null)]
-        public void CubePower_Valid(object value, decimal? expected)
+        public void CubePower_Valid(object? value, decimal? expected)
             => Assert.That(new CubePower().Evaluate(value), Is.EqualTo(expected));
 
         [Test]
@@ -47,7 +47,7 @@ namespace Expressif.Testing.Functions.Numeric
         [TestCase(2, 5, 32)]
         [TestCase(-2, 5, -32)]
         [TestCase(null, 1, null)]
-        public void Power_Exponent_Valid(object value, decimal exponent, decimal? expected)
+        public void Power_Exponent_Valid(object? value, decimal exponent, decimal? expected)
             => Assert.That(new Power(() => exponent).Evaluate(value), Is.EqualTo(expected));
 
         [Test]
@@ -56,7 +56,7 @@ namespace Expressif.Testing.Functions.Numeric
         [TestCase(4, 2)]
         [TestCase(9, 3)]
         [TestCase(null, null)]
-        public void SquareRoot_Valid(object value, decimal? expected)
+        public void SquareRoot_Valid(object? value, decimal? expected)
             => Assert.That(new SquareRoot().Evaluate(value), Is.EqualTo(expected));
 
         [Test]
@@ -66,7 +66,7 @@ namespace Expressif.Testing.Functions.Numeric
         [TestCase(8, 2)]
         [TestCase(-8, -2)]
         [TestCase(null, null)]
-        public void CubeRoot_Valid(object value, decimal? expected)
+        public void CubeRoot_Valid(object? value, decimal? expected)
             => Assert.That(new CubeRoot().Evaluate(value), Is.EqualTo(expected));
 
         [Test]
@@ -83,7 +83,7 @@ namespace Expressif.Testing.Functions.Numeric
         [TestCase(32, 5, 2)]
         [TestCase(-32, 5, -2)]
         [TestCase(null, 1, null)]
-        public void NthRoot_Exponent_Valid(object value, decimal exponent, decimal? expected)
+        public void NthRoot_Exponent_Valid(object? value, decimal exponent, decimal? expected)
             => Assert.That(new NthRoot(() => exponent).Evaluate(value), Is.EqualTo(expected));
     }
 }

--- a/Expressif.Testing/Functions/Numeric/SignFunctionsTest.cs
+++ b/Expressif.Testing/Functions/Numeric/SignFunctionsTest.cs
@@ -16,7 +16,7 @@ namespace Expressif.Testing.Functions.Numeric
         [TestCase(5, 1)]
         [TestCase(-5, -1)]
         [TestCase(null, null)]
-        public void Sign_Valid(object value, decimal? expected)
+        public void Sign_Valid(object? value, decimal? expected)
             => Assert.That(new Sign().Evaluate(value), Is.EqualTo(expected));
 
         [Test]
@@ -26,7 +26,7 @@ namespace Expressif.Testing.Functions.Numeric
         [TestCase(5, 5)]
         [TestCase(-5, 5)]
         [TestCase(null, null)]
-        public void Absolute_Valid(object value, decimal? expected)
+        public void Absolute_Valid(object? value, decimal? expected)
             => Assert.That(new Absolute().Evaluate(value), Is.EqualTo(expected));
     }
 }

--- a/Expressif.Testing/Functions/Special/SpecialFunctionsTest.cs
+++ b/Expressif.Testing/Functions/Special/SpecialFunctionsTest.cs
@@ -16,7 +16,7 @@ namespace Expressif.Testing.Functions.Special
         [TestCase("(null)")]
         [TestCase(null)]
         [TestCase(150)]
-        public void AnyToAny_Any(object value)
+        public void AnyToAny_Any(object? value)
             => Assert.That(new AnyToAny().Evaluate(value), Is.EqualTo(new Any()));
 
         [Test]
@@ -60,7 +60,7 @@ namespace Expressif.Testing.Functions.Special
         [Test]
         [TestCase("(null)")]
         [TestCase(null)]
-        public void ValueToValue_Null_Null(object value)
+        public void ValueToValue_Null_Null(object? value)
             => Assert.That(new ValueToValue().Evaluate(value), Is.EqualTo(new Null()));
 
         [Test]
@@ -80,7 +80,7 @@ namespace Expressif.Testing.Functions.Special
         [Test]
         [TestCase("(null)")]
         [TestCase(null)]
-        public void NullToValue_Null_Value(object value)
+        public void NullToValue_Null_Value(object? value)
             => Assert.That(new NullToValue().Evaluate(value), Is.EqualTo(new Value()));
 
         [Test]

--- a/Expressif.Testing/Functions/Temporal/TemporalFunctionsTest.cs
+++ b/Expressif.Testing/Functions/Temporal/TemporalFunctionsTest.cs
@@ -193,7 +193,7 @@ namespace Expressif.Testing.Functions.Temporal
         [TestCase("2018-02-31", "2001-01-01")]
         [TestCase("(null)", null)]
         [TestCase(null, null)]
-        public void InvalidToDate_Valid(object value, DateTime? expected)
+        public void InvalidToDate_Valid(object? value, DateTime? expected)
             => Assert.That(new InvalidToDate(() => new DateTime(2001, 1, 1)).Evaluate(value)
                 , Is.EqualTo(expected == null ? new Null() : expected));
 
@@ -210,7 +210,7 @@ namespace Expressif.Testing.Functions.Temporal
         [TestCase("2018-02-12 07:00:00", "2018-02-01")]
         [TestCase(null, null)]
         [TestCase("(null)", null)]
-        public void FirstOfMonth_Valid(object value, DateTime? expected)
+        public void FirstOfMonth_Valid(object? value, DateTime? expected)
         {
             var function = new FirstOfMonth();
             var result = function.Evaluate(value);
@@ -226,7 +226,7 @@ namespace Expressif.Testing.Functions.Temporal
         [TestCase("2018-02-12 07:00:00", "2018-01-01")]
         [TestCase(null, null)]
         [TestCase("(null)", null)]
-        public void FirstOfYear_Valid(object value, DateTime? expected)
+        public void FirstOfYear_Valid(object? value, DateTime? expected)
         {
             var function = new FirstOfYear();
             var result = function.Evaluate(value);
@@ -243,7 +243,7 @@ namespace Expressif.Testing.Functions.Temporal
         [TestCase("2020-02-12 07:00:00", "2020-02-29")]
         [TestCase(null, null)]
         [TestCase("(null)", null)]
-        public void LastOfMonth_Valid(object value, DateTime? expected)
+        public void LastOfMonth_Valid(object? value, DateTime? expected)
         {
             var function = new LastOfMonth();
             var result = function.Evaluate(value);
@@ -259,7 +259,7 @@ namespace Expressif.Testing.Functions.Temporal
         [TestCase("2018-02-12 07:00:00", "2018-12-31")]
         [TestCase(null, null)]
         [TestCase("(null)", null)]
-        public void LastOfYear_Valid(object value, DateTime? expected)
+        public void LastOfYear_Valid(object? value, DateTime? expected)
         {
             var function = new LastOfYear();
             var result = function.Evaluate(value);

--- a/Expressif.Testing/Functions/Text/CountingFunctionsTest.cs
+++ b/Expressif.Testing/Functions/Text/CountingFunctionsTest.cs
@@ -55,7 +55,7 @@ namespace Expressif.Testing.Functions.Text
         [TestCase("(blank)", 0)]
         [TestCase("1 2017-07-06      CUST0001", 3)]
         [TestCase("1 2017-07-06          CUST0001", 3)]
-        public void TokenCount_Valid(object value, int expected)
+        public void TokenCount_Valid(object? value, int expected)
             => Assert.That(new TokenCount().Evaluate(value), Is.EqualTo(expected));
     }
 }

--- a/Expressif.Testing/Functions/Text/TextFunctionsTest.cs
+++ b/Expressif.Testing/Functions/Text/TextFunctionsTest.cs
@@ -231,7 +231,7 @@ namespace Expressif.Testing.Functions.Text
         [TestCase(null, "(null)")]
         [TestCase("(empty)", "(empty)")]
         [TestCase("(blank)", "(empty)")]
-        public void WithoutWhitespaces_Valid(object value, string expected)
+        public void WithoutWhitespaces_Valid(object? value, string expected)
             => Assert.That(new WithoutWhitespaces().Evaluate(value), Is.EqualTo(expected));
 
         [Test]

--- a/Expressif.Testing/Predicates/Boolean/IdenticalToTest.cs
+++ b/Expressif.Testing/Predicates/Boolean/IdenticalToTest.cs
@@ -35,7 +35,7 @@ namespace Expressif.Testing.Predicates.Boolean
         [TestCase("false", false, true)]
         [TestCase("yes", false, false)]
         [TestCase("no", false, true)]
-        public void False_Boolean_Expected(object value, bool reference, bool expected)
+        public void False_Boolean_Expected(object? value, bool reference, bool expected)
             => Assert.That(new IdenticalTo(() => reference).Evaluate(value), Is.EqualTo(expected));
     }
 }

--- a/Expressif.Testing/Predicates/Boolean/TrueFalseTest.cs
+++ b/Expressif.Testing/Predicates/Boolean/TrueFalseTest.cs
@@ -22,7 +22,7 @@ namespace Expressif.Testing.Predicates.Boolean
         [TestCase("false", false)]
         [TestCase("yes", true)]
         [TestCase("no", false)]
-        public void True_Boolean_Expected(object value, bool expected)
+        public void True_Boolean_Expected(object? value, bool expected)
             => Assert.That(new True().Evaluate(value), Is.EqualTo(expected));
 
         [Test]
@@ -38,7 +38,7 @@ namespace Expressif.Testing.Predicates.Boolean
         [TestCase("false", false)]
         [TestCase("yes", true)]
         [TestCase("no", false)]
-        public void TrueOrNull_Boolean_Expected(object value, bool expected)
+        public void TrueOrNull_Boolean_Expected(object? value, bool expected)
             => Assert.That(new TrueOrNull().Evaluate(value), Is.EqualTo(expected));
 
         [Test]
@@ -54,7 +54,7 @@ namespace Expressif.Testing.Predicates.Boolean
         [TestCase("false", true)]
         [TestCase("yes", false)]
         [TestCase("no", true)]
-        public void False_Boolean_Expected(object value, bool expected)
+        public void False_Boolean_Expected(object? value, bool expected)
             => Assert.That(new False().Evaluate(value), Is.EqualTo(expected));
 
         [Test]
@@ -70,7 +70,7 @@ namespace Expressif.Testing.Predicates.Boolean
         [TestCase("false", true)]
         [TestCase("yes", false)]
         [TestCase("no", true)]
-        public void FalseOrNull_Boolean_Expected(object value, bool expected)
+        public void FalseOrNull_Boolean_Expected(object? value, bool expected)
             => Assert.That(new FalseOrNull().Evaluate(value), Is.EqualTo(expected));
     }
 }

--- a/Expressif.Testing/Predicates/Numeric/ComparisonShortcutTest.cs
+++ b/Expressif.Testing/Predicates/Numeric/ComparisonShortcutTest.cs
@@ -15,7 +15,7 @@ namespace Expressif.Testing.Predicates.Numeric
         [TestCase(10, false)]
         [TestCase(-10, false)]
         [TestCase(null, false)]
-        public void Zero_Numeric_Success(object value, bool expected)
+        public void Zero_Numeric_Success(object? value, bool expected)
             => Assert.That(new Zero().Evaluate(value), Is.EqualTo(expected));
 
         [Test]
@@ -24,7 +24,7 @@ namespace Expressif.Testing.Predicates.Numeric
         [TestCase(10, false)]
         [TestCase(-10, false)]
         [TestCase(null, false)]
-        public void One_Numeric_Success(object value, bool expected)
+        public void One_Numeric_Success(object? value, bool expected)
             => Assert.That(new One().Evaluate(value), Is.EqualTo(expected));
 
         [Test]
@@ -33,7 +33,7 @@ namespace Expressif.Testing.Predicates.Numeric
         [TestCase(10, true)]
         [TestCase(-10, false)]
         [TestCase(null, false)]
-        public void Positive_Numeric_Success(object value, bool expected)
+        public void Positive_Numeric_Success(object? value, bool expected)
             => Assert.That(new Positive().Evaluate(value), Is.EqualTo(expected));
 
         [Test]
@@ -42,7 +42,7 @@ namespace Expressif.Testing.Predicates.Numeric
         [TestCase(10, true)]
         [TestCase(-10, false)]
         [TestCase(null, false)]
-        public void PositiveOrZero_Numeric_Success(object value, bool expected)
+        public void PositiveOrZero_Numeric_Success(object? value, bool expected)
             => Assert.That(new PositiveOrZero().Evaluate(value), Is.EqualTo(expected));
 
         [Test]
@@ -51,7 +51,7 @@ namespace Expressif.Testing.Predicates.Numeric
         [TestCase(10, false)]
         [TestCase(-10, true)]
         [TestCase(null, false)]
-        public void Negative_Numeric_Success(object value, bool expected)
+        public void Negative_Numeric_Success(object? value, bool expected)
             => Assert.That(new Negative().Evaluate(value), Is.EqualTo(expected));
 
         [Test]
@@ -60,7 +60,7 @@ namespace Expressif.Testing.Predicates.Numeric
         [TestCase(10, false)]
         [TestCase(-10, true)]
         [TestCase(null, false)]
-        public void NegativeOrZero_Numeric_Success(object value, bool expected)
+        public void NegativeOrZero_Numeric_Success(object? value, bool expected)
             => Assert.That(new NegativeOrZero().Evaluate(value), Is.EqualTo(expected));
     }
 }

--- a/Expressif.Testing/Predicates/Numeric/ComparisonTest.cs
+++ b/Expressif.Testing/Predicates/Numeric/ComparisonTest.cs
@@ -19,7 +19,7 @@ namespace Expressif.Testing.Predicates.Numeric
         [TestCase(4.001, 4, false)]
         [TestCase(3.999, 4, false)]
         [TestCase(null, 4, false)]
-        public void Equal_Numeric_Success(object value, decimal reference, bool expected)
+        public void Equal_Numeric_Success(object? value, decimal reference, bool expected)
         {
             var predicate = new EqualTo(() => reference);
             Assert.Multiple(() =>
@@ -36,7 +36,7 @@ namespace Expressif.Testing.Predicates.Numeric
         [TestCase(4.001, 4, true)]
         [TestCase(3.999, 4, false)]
         [TestCase(null, 4, false)]
-        public void GreaterThan_Numeric_Success(object value, decimal reference, bool expected)
+        public void GreaterThan_Numeric_Success(object? value, decimal reference, bool expected)
         {
             var predicate = new GreaterThan(() => reference);
             Assert.Multiple(() =>
@@ -53,7 +53,7 @@ namespace Expressif.Testing.Predicates.Numeric
         [TestCase(4.001, 4, true)]
         [TestCase(3.999, 4, false)]
         [TestCase(null, 4, false)]
-        public void GreaterThanOrEqual_Numeric_Success(object value, decimal reference, bool expected)
+        public void GreaterThanOrEqual_Numeric_Success(object? value, decimal reference, bool expected)
         {
             var predicate = new GreaterThanOrEqual(() => reference);
             Assert.Multiple(() =>
@@ -70,7 +70,7 @@ namespace Expressif.Testing.Predicates.Numeric
         [TestCase(4.001, 4, false)]
         [TestCase(3.999, 4, true)]
         [TestCase(null, 4, false)]
-        public void LessThan_Numeric_Success(object value, decimal reference, bool expected)
+        public void LessThan_Numeric_Success(object? value, decimal reference, bool expected)
         {
             var predicate = new LessThan(() => reference);
             Assert.Multiple(() =>
@@ -87,7 +87,7 @@ namespace Expressif.Testing.Predicates.Numeric
         [TestCase(4.001, 4, false)]
         [TestCase(3.999, 4, true)]
         [TestCase(null, 4, false)]
-        public void LessThanOrEqual_Numeric_Success(object value, decimal reference, bool expected)
+        public void LessThanOrEqual_Numeric_Success(object? value, decimal reference, bool expected)
         {
             var predicate = new LessThanOrEqual(() => reference);
             Assert.Multiple(() =>
@@ -106,7 +106,7 @@ namespace Expressif.Testing.Predicates.Numeric
         [TestCase(-4, 5, false)]
         [TestCase(-4, -4, false)]
         [TestCase(null, 4, false)]
-        public void Opposite_Numeric_Success(object value, decimal reference, bool expected)
+        public void Opposite_Numeric_Success(object? value, decimal reference, bool expected)
         {
             var predicate = new Opposite(() => reference);
             Assert.Multiple(() =>

--- a/Expressif.Testing/Predicates/Numeric/IntervalTest.cs
+++ b/Expressif.Testing/Predicates/Numeric/IntervalTest.cs
@@ -15,7 +15,7 @@ namespace Expressif.Testing.Predicates.Numeric
         [TestCase(1, false)]
         [TestCase(12, true)]
         [TestCase(null, false)]
-        public void WithinInterval_Numeric_Success(object value, bool expected)
+        public void WithinInterval_Numeric_Success(object? value, bool expected)
             => Assert.That(new WithinInterval(() => new Interval<decimal>(1,12,IntervalType.Open,IntervalType.Closed)).Evaluate(value), Is.EqualTo(expected));
     }
 }

--- a/Expressif.Testing/Predicates/Numeric/ModuloTest.cs
+++ b/Expressif.Testing/Predicates/Numeric/ModuloTest.cs
@@ -29,7 +29,7 @@ namespace Expressif.Testing.Predicates.Numeric
         [TestCase(10, 6, 0)]
         [TestCase(10, 5, 1)]
         [TestCase(null, 5, 2)]
-        public void Modulo_Numeric_Failure(object value, int modulus, int remainder)
+        public void Modulo_Numeric_Failure(object? value, int modulus, int remainder)
         {
             var predicate = new Modulo(() => modulus, () => remainder);
             Assert.Multiple(() =>
@@ -45,7 +45,7 @@ namespace Expressif.Testing.Predicates.Numeric
         [TestCase(1, false)]
         [TestCase(0, true)]
         [TestCase(null, false)]
-        public void Even_Numeric_Valid(object value, bool expected)
+        public void Even_Numeric_Valid(object? value, bool expected)
         {
             var predicate = new Even();
             Assert.That(predicate.Evaluate(value), Is.EqualTo(expected));
@@ -56,7 +56,7 @@ namespace Expressif.Testing.Predicates.Numeric
         [TestCase(1, true)]
         [TestCase(0, false)]
         [TestCase(null, false)]
-        public void Odd_Numeric_Valid(object value, bool expected)
+        public void Odd_Numeric_Valid(object? value, bool expected)
         {
             var predicate = new Odd();
             Assert.That(predicate.Evaluate(value), Is.EqualTo(expected));

--- a/Expressif.Testing/Predicates/Numeric/SpecialTest.cs
+++ b/Expressif.Testing/Predicates/Numeric/SpecialTest.cs
@@ -16,7 +16,7 @@ namespace Expressif.Testing.Predicates.Numeric
         [TestCase(4.25, false)]
         [TestCase(null, false)]
         [TestCase("(null)", false)]
-        public void Integer_Numeric_Success(object value, bool expected)
+        public void Integer_Numeric_Success(object? value, bool expected)
             => Assert.That(new Integer().Evaluate(value), Is.EqualTo(expected));
 
         [Test]
@@ -26,7 +26,7 @@ namespace Expressif.Testing.Predicates.Numeric
         [TestCase(4.25, false)]
         [TestCase(null, true)]
         [TestCase("(null)", true)]
-        public void ZeroOrNull_Numeric_Success(object value, bool expected)
+        public void ZeroOrNull_Numeric_Success(object? value, bool expected)
             => Assert.That(new ZeroOrNull().Evaluate(value), Is.EqualTo(expected));
     }
 }

--- a/Expressif.Testing/Predicates/Special/NullTest.cs
+++ b/Expressif.Testing/Predicates/Special/NullTest.cs
@@ -18,7 +18,7 @@ namespace Expressif.Testing.Predicates.Special
         [TestCase("(empty)", false)]
         [TestCase("(blank)", false)]
         [TestCase("foo", false)]
-        public void Null_Numeric_Success(object value, bool expected)
+        public void Null_Numeric_Success(object? value, bool expected)
         => Assert.That(new Null().Evaluate(value), Is.EqualTo(expected));
     }
 }

--- a/Expressif.Testing/Predicates/Temporal/ComparisonTest.cs
+++ b/Expressif.Testing/Predicates/Temporal/ComparisonTest.cs
@@ -17,7 +17,7 @@ namespace Expressif.Testing.Predicates.Temporal
         [TestCase("2022-11-21 17:12:25", "2022-11-21 17:12:24", false)]
         [TestCase(null, "2022-11-21", false)]
         [TestCase("(null)", "2022-11-21", false)]
-        public void SameInstant_DateTime_Expected(object value, DateTime reference, bool expected)
+        public void SameInstant_DateTime_Expected(object? value, DateTime reference, bool expected)
             => Assert.That(new SameInstant(() => reference).Evaluate(value), Is.EqualTo(expected));
 
         [Test]
@@ -27,7 +27,7 @@ namespace Expressif.Testing.Predicates.Temporal
         [TestCase("2022-11-21 17:12:25", "2022-11-21 17:12:24", true)]
         [TestCase(null, "2022-11-21", false)]
         [TestCase("(null)", "2022-11-21", false)]
-        public void After_DateTime_Expected(object value, DateTime reference, bool expected)
+        public void After_DateTime_Expected(object? value, DateTime reference, bool expected)
             => Assert.That(new After(() => reference).Evaluate(value), Is.EqualTo(expected));
 
         [Test]
@@ -37,7 +37,7 @@ namespace Expressif.Testing.Predicates.Temporal
         [TestCase("2022-11-21 17:12:25", "2022-11-21 17:12:24", true)]
         [TestCase(null, "2022-11-21", false)]
         [TestCase("(null)", "2022-11-21", false)]
-        public void AfterOrSameInstant_DateTime_Expected(object value, DateTime reference, bool expected)
+        public void AfterOrSameInstant_DateTime_Expected(object? value, DateTime reference, bool expected)
             => Assert.That(new AfterOrSameInstant(() => reference).Evaluate(value), Is.EqualTo(expected));
 
         [Test]
@@ -47,7 +47,7 @@ namespace Expressif.Testing.Predicates.Temporal
         [TestCase("2022-11-21 17:12:25", "2022-11-21 17:12:24", false)]
         [TestCase(null, "2022-11-21", false)]
         [TestCase("(null)", "2022-11-21", false)]
-        public void Before_DateTime_Expected(object value, DateTime reference, bool expected)
+        public void Before_DateTime_Expected(object? value, DateTime reference, bool expected)
             => Assert.That(new Before(() => reference).Evaluate(value), Is.EqualTo(expected));
 
         [Test]
@@ -57,7 +57,7 @@ namespace Expressif.Testing.Predicates.Temporal
         [TestCase("2022-11-21 17:12:25", "2022-11-21 17:12:24", false)]
         [TestCase(null, "2022-11-21", false)]
         [TestCase("(null)", "2022-11-21", false)]
-        public void BeforeOrSameInstant_DateTime_Expected(object value, DateTime reference, bool expected)
+        public void BeforeOrSameInstant_DateTime_Expected(object? value, DateTime reference, bool expected)
             => Assert.That(new BeforeOrSameInstant(() => reference).Evaluate(value), Is.EqualTo(expected));
     }
 }

--- a/Expressif.Testing/Predicates/Temporal/IntervalTest.cs
+++ b/Expressif.Testing/Predicates/Temporal/IntervalTest.cs
@@ -18,7 +18,7 @@ namespace Expressif.Testing.Predicates.Temporal
         [TestCase("2022-11-25 17:12:25", false)]
         [TestCase(null, false)]
         [TestCase("(null)", false)]
-        public void ContainedIn_DateTime_Expected(object value, bool expected)
+        public void ContainedIn_DateTime_Expected(object? value, bool expected)
             => Assert.That(new ContainedIn(
                 new Interval<System.DateTime>(
                     new System.DateTime(2022, 11, 20)

--- a/Expressif.Testing/Predicates/Temporal/OnTheInstantTest.cs
+++ b/Expressif.Testing/Predicates/Temporal/OnTheInstantTest.cs
@@ -17,7 +17,7 @@ namespace Expressif.Testing.Predicates.Temporal
         [TestCase("2022-11-21 17:12:25", false)]
         [TestCase(null, false)]
         [TestCase("(null)", false)]
-        public void OnTheDay_DateTime_Expected(object value, bool expected)
+        public void OnTheDay_DateTime_Expected(object? value, bool expected)
             => Assert.That(new OnTheDay().Evaluate(value), Is.EqualTo(expected));
 
         [Test]
@@ -33,7 +33,7 @@ namespace Expressif.Testing.Predicates.Temporal
         [TestCase("2022-11-21 17:12:25", false)]
         [TestCase(null, false)]
         [TestCase("(null)", false)]
-        public void OnTheHour_DateTime_Expected(object value, bool expected)
+        public void OnTheHour_DateTime_Expected(object? value, bool expected)
             => Assert.That(new OnTheHour().Evaluate(value), Is.EqualTo(expected));
 
         [Test]
@@ -49,7 +49,7 @@ namespace Expressif.Testing.Predicates.Temporal
         [TestCase("2022-11-21 17:12:25", false)]
         [TestCase(null, false)]
         [TestCase("(null)", false)]
-        public void OnTheMinute_DateTime_Expected(object value, bool expected)
+        public void OnTheMinute_DateTime_Expected(object? value, bool expected)
             => Assert.That(new OnTheMinute().Evaluate(value), Is.EqualTo(expected));
 
         [Test]

--- a/Expressif.Testing/Predicates/Text/CasingTest.cs
+++ b/Expressif.Testing/Predicates/Text/CasingTest.cs
@@ -19,7 +19,7 @@ namespace Expressif.Testing.Predicates.Text
         [TestCase("(empty)", true)]
         [TestCase("(null)", true)]
         [TestCase(null, true)]
-        public void LowerCase_Text_Success(object value, bool expected)
+        public void LowerCase_Text_Success(object? value, bool expected)
             => Assert.That(new LowerCase().Evaluate(value), Is.EqualTo(expected));
 
         [TestCase("Foobar", false)]
@@ -32,7 +32,7 @@ namespace Expressif.Testing.Predicates.Text
         [TestCase("(empty)", true)]
         [TestCase("(null)", true)]
         [TestCase(null, true)]
-        public void UpperCase_Text_Success(object value, bool expected)
+        public void UpperCase_Text_Success(object? value, bool expected)
             => Assert.That(new UpperCase().Evaluate(value), Is.EqualTo(expected));
     }
 }

--- a/Expressif.Testing/Predicates/Text/MatchingTest.cs
+++ b/Expressif.Testing/Predicates/Text/MatchingTest.cs
@@ -29,7 +29,7 @@ namespace Expressif.Testing.Predicates.Text
         [TestCase(null, false)]
         [TestCase(125.17, true)]
         [TestCase(125, true)]
-        public void MatchesNumeric_InvariantCulture_Success(object value, bool expected)
+        public void MatchesNumeric_InvariantCulture_Success(object? value, bool expected)
             => Assert.That(new MatchesNumeric().Evaluate(value), Is.EqualTo(expected));
 
         [Test]
@@ -51,7 +51,7 @@ namespace Expressif.Testing.Predicates.Text
         [TestCase(null, false)]
         [TestCase(125.17, true)]
         [TestCase(125, true)]
-        public void MatchesNumeric_FrenchCulture_Success(object value, bool expected)
+        public void MatchesNumeric_FrenchCulture_Success(object? value, bool expected)
             => Assert.That(new MatchesNumeric(() => "fr-fr").Evaluate(value), Is.EqualTo(expected));
 
         [Test]
@@ -70,7 +70,7 @@ namespace Expressif.Testing.Predicates.Text
         [TestCase("", false)]
         [TestCase("(null)", false)]
         [TestCase(null, false)]
-        public void MatchesDate_InvariantCulture_Success(object value, bool expected)
+        public void MatchesDate_InvariantCulture_Success(object? value, bool expected)
             => Assert.That(new MatchesDate().Evaluate(value), Is.EqualTo(expected));
 
         [Test]
@@ -105,7 +105,7 @@ namespace Expressif.Testing.Predicates.Text
         [TestCase("", false)]
         [TestCase("(null)", false)]
         [TestCase(null, false)]
-        public void MatchesDate_FrenchCulture_Success(object value, bool expected)
+        public void MatchesDate_FrenchCulture_Success(object? value, bool expected)
             => Assert.That(new MatchesDate(() => "fr-fr").Evaluate(value), Is.EqualTo(expected));
 
         [Test]
@@ -133,7 +133,7 @@ namespace Expressif.Testing.Predicates.Text
         [TestCase("", false)]
         [TestCase("(null)", false)]
         [TestCase(null, false)]
-        public void MatchesDate_DutchCulture_Success(object value, bool expected)
+        public void MatchesDate_DutchCulture_Success(object? value, bool expected)
             => Assert.That(new MatchesDate(() => "nl-be").Evaluate(value), Is.EqualTo(expected));
 
         [Test]
@@ -152,7 +152,7 @@ namespace Expressif.Testing.Predicates.Text
         [TestCase("", false)]
         [TestCase("(null)", false)]
         [TestCase(null, false)]
-        public void MatchesDateTime_InvariantCulture_Success(object value, bool expected)
+        public void MatchesDateTime_InvariantCulture_Success(object? value, bool expected)
             => Assert.That(new MatchesDateTime().Evaluate(value), Is.EqualTo(expected));
 
         [Test]
@@ -187,7 +187,7 @@ namespace Expressif.Testing.Predicates.Text
         [TestCase("", false)]
         [TestCase("(null)", false)]
         [TestCase(null, false)]
-        public void MatchesTime_InvariantCulture_Success(object value, bool expected)
+        public void MatchesTime_InvariantCulture_Success(object? value, bool expected)
             => Assert.That(new MatchesTime().Evaluate(value), Is.EqualTo(expected));
 
         [Test]
@@ -206,7 +206,7 @@ namespace Expressif.Testing.Predicates.Text
         [TestCase("", false)]
         [TestCase("(null)", false)]
         [TestCase(null, false)]
-        public void MatchesTime_EnglishCulture_Success(object value, bool expected)
+        public void MatchesTime_EnglishCulture_Success(object? value, bool expected)
             => Assert.That(new MatchesTime(() => "en-gb").Evaluate(value), Is.EqualTo(expected));
 
         [Test]

--- a/Expressif.Testing/Predicates/Text/SpecialTest.cs
+++ b/Expressif.Testing/Predicates/Text/SpecialTest.cs
@@ -16,7 +16,7 @@ namespace Expressif.Testing.Predicates.Text
         [TestCase("(empty)", true)]
         [TestCase("(blank)", false)]
         [TestCase("foo", false)]
-        public void Empty_Text_Success(object value, bool expected)
+        public void Empty_Text_Success(object? value, bool expected)
             => Assert.That(new Empty().Evaluate(value), Is.EqualTo(expected));
 
         [Test]
@@ -26,7 +26,7 @@ namespace Expressif.Testing.Predicates.Text
         [TestCase("(empty)", true)]
         [TestCase("(blank)", false)]
         [TestCase("foo", false)]
-        public void NullOrEmpty_Text_Success(object value, bool expected)
+        public void NullOrEmpty_Text_Success(object? value, bool expected)
             => Assert.That(new EmptyOrNull().Evaluate(value), Is.EqualTo(expected));
     }
 }

--- a/Expressif.Testing/Predicates/Text/SubstringTest.cs
+++ b/Expressif.Testing/Predicates/Text/SubstringTest.cs
@@ -74,7 +74,7 @@ namespace Expressif.Testing.Predicates.Text
         [TestCase("", "^[A-Z]+$", false)]
         [TestCase("(null)", "^[A-Z]+$", false)]
         [TestCase(null, "^[A-Z]+$", false)]
-        public void MatchesRegex_TextIgnoreCase_Success(object value, string reference, bool expected)
+        public void MatchesRegex_TextIgnoreCase_Success(object? value, string reference, bool expected)
         {
             var predicate = new MatchesRegex(() => reference);
             Assert.Multiple(() =>

--- a/Expressif.Testing/Values/Special/AnyTest.cs
+++ b/Expressif.Testing/Values/Special/AnyTest.cs
@@ -16,7 +16,7 @@ namespace Expressif.Testing.Values.Special
         [TestCase("(blank)")]
         [TestCase("(any)")]
         [TestCase("(value)")]
-        public void Equals_Any_Valid(object value)
+        public void Equals_Any_Valid(object? value)
             => Assert.That(new Any().Equals(value), Is.True);
 
         [Test]
@@ -27,7 +27,7 @@ namespace Expressif.Testing.Values.Special
         [TestCase("(blank)")]
         [TestCase("(any)")]
         [TestCase("(value)")]
-        public void EqualOperator_Null_Valid(object value)
+        public void EqualOperator_Null_Valid(object? value)
             => Assert.That(new Any() == value, Is.True);
 
         [Test]

--- a/Expressif.Testing/Values/Special/ValueTest.cs
+++ b/Expressif.Testing/Values/Special/ValueTest.cs
@@ -19,7 +19,7 @@ namespace Expressif.Testing.Values.Special
         [Test]
         [TestCase(null)]
         [TestCase("(null)")]
-        public void Equals_Null_Invalid(object value)
+        public void Equals_Null_Invalid(object? value)
             => Assert.That(new Value().Equals(value), Is.False);
 
         [Test]
@@ -27,13 +27,13 @@ namespace Expressif.Testing.Values.Special
         [TestCase("(empty)")]
         [TestCase("(blank)")]
         [TestCase("(value)")]
-        public void EqualOperator_Value_Valid(object value)
+        public void EqualOperator_Value_Valid(object? value)
             => Assert.That(new Value() == value, Is.True);
 
         [Test]
         [TestCase(null)]
         [TestCase("(null)")]
-        public void EqualOperator_Null_Invalid(object value)
+        public void EqualOperator_Null_Invalid(object? value)
             => Assert.That(new Value() == value, Is.False);
 
         [Test]


### PR DESCRIPTION
change function parameter from `object` to `object?` when testing with `null` values