### PR TITLE
fix: prevent failure loading ops when XML is missing

### DIFF
--- a/Expressif.Testing/Functions/Introspection/FunctionIntrospectorTest.cs
+++ b/Expressif.Testing/Functions/Introspection/FunctionIntrospectorTest.cs
@@ -18,7 +18,7 @@ public class FunctionIntrospectorTest
 
     [SetUp]
     public void Setup()
-        => Infos ??= new FunctionIntrospector().Locate();
+        => Infos ??= new FunctionIntrospector().Describe();
 
     [Test]
     public void Locate_ExpressifAssembly_ElementsReturned()

--- a/Expressif.Testing/Predicates/Introspection/PredicateIntrospectorTest.cs
+++ b/Expressif.Testing/Predicates/Introspection/PredicateIntrospectorTest.cs
@@ -18,7 +18,7 @@ public class PredicateIntrospectorTest
 
     [SetUp]
     public void Setup()
-        => Infos ??= new PredicateIntrospector().Locate();
+        => Infos ??= new PredicateIntrospector().Describe();
 
     [Test]
     public void Locate_ExpressifAssembly_ElementsReturned()

--- a/Expressif.Testing/Predicates/Operators/OperatorIntrospectorTest.cs
+++ b/Expressif.Testing/Predicates/Operators/OperatorIntrospectorTest.cs
@@ -18,7 +18,7 @@ internal class OperatorIntrospectorTest
 
     [SetUp]
     public void Setup()
-        => Infos ??= new OperatorIntrospector().Locate().ToArray();
+        => Infos ??= new OperatorIntrospector().Describe().ToArray();
 
     [Test]
     public void Locate_ExpressifAssembly_ElementsReturned()

--- a/Expressif/Functions/Introspection/FunctionIntrospector.cs
+++ b/Expressif/Functions/Introspection/FunctionIntrospector.cs
@@ -17,9 +17,12 @@ public class FunctionIntrospector : BaseIntrospector
         : base(probe) { }
 
     public IEnumerable<FunctionInfo> Locate()
-        => Locate<FunctionAttribute>();
+        => Locate<FunctionAttribute>(true);
 
-    protected IEnumerable<FunctionInfo> Locate<T>() where T : FunctionAttribute
+    public IEnumerable<FunctionInfo> Describe()
+        => Locate<FunctionAttribute>(false);
+
+    protected IEnumerable<FunctionInfo> Locate<T>(bool fast) where T : FunctionAttribute
     {
         var functions = LocateAttribute<FunctionAttribute>();
 
@@ -37,8 +40,8 @@ public class FunctionIntrospector : BaseIntrospector
                             ).Where(x => !string.IsNullOrEmpty(x)).ToArray()
                     , function.Type.Namespace!.ToToken('.').Last()
                     , function.Type
-                    , function.Type.GetSummary()
-                    , BuildParameters(function.Type.GetInfoConstructors()).ToArray()
+                    , fast ? "" : function.Type.GetSummary()
+                    , fast ? [] : BuildParameters(function.Type.GetInfoConstructors()).ToArray()
                 );
         }
     }

--- a/Expressif/Predicates/Introspection/PredicateIntrospector.cs
+++ b/Expressif/Predicates/Introspection/PredicateIntrospector.cs
@@ -18,9 +18,12 @@ public class PredicateIntrospector : BaseIntrospector
         : base(probe) { }
 
     public IEnumerable<PredicateInfo> Locate()
-        => Locate<PredicateAttribute>();
+        => Locate<PredicateAttribute>(true);
 
-    protected IEnumerable<PredicateInfo> Locate<T>() where T : PredicateAttribute
+    public IEnumerable<PredicateInfo> Describe()
+        => Locate<PredicateAttribute>(false);
+
+    protected IEnumerable<PredicateInfo> Locate<T>(bool fast = true) where T : PredicateAttribute
     {
         var predicates = LocateAttribute<PredicateAttribute>();
 
@@ -42,8 +45,8 @@ public class PredicateIntrospector : BaseIntrospector
                     , predicate.Attribute.Aliases.AsQueryable().Prepend(string.Join('-', array)).ToArray()
                     , predicate.Type.Namespace!.ToToken('.').Last()
                     , predicate.Type
-                    , predicate.Type.GetSummary()
-                    , BuildParameters(predicate.Type.GetInfoConstructors()).ToArray()
+                    , fast ? "" : predicate.Type.GetSummary()
+                    , fast ? [] : BuildParameters(predicate.Type.GetInfoConstructors()).ToArray()
                 );
         }
     }

--- a/Expressif/Predicates/Operators/OperatorIntrospector.cs
+++ b/Expressif/Predicates/Operators/OperatorIntrospector.cs
@@ -17,6 +17,12 @@ internal class OperatorIntrospector : BaseIntrospector
         : base(probe) { }
 
     public IEnumerable<OperatorInfo> Locate()
+        => Locate(true);
+
+    public IEnumerable<OperatorInfo> Describe()
+        => Locate(false);
+
+    protected IEnumerable<OperatorInfo> Locate(bool fast = true)
     {
         var operators = LocateAttribute<OperatorAttribute>();
 
@@ -27,7 +33,7 @@ internal class OperatorIntrospector : BaseIntrospector
                     , @operator.Type.IsPublic
                     , @operator.Attribute.Aliases
                     , @operator.Type
-                    , @operator.Type.GetSummary()
+                    , fast ? "" : @operator.Type.GetSummary()
                 );
         }
     }

--- a/generate-info.ps1
+++ b/generate-info.ps1
@@ -34,7 +34,7 @@ $job = Start-Job -ScriptBlock { param($fullDllPath, $class, $destination)
     $elapsed = Measure-Command -Expression {
         $TextInfo = (Get-Culture).TextInfo
         $locator = New-Object -TypeName "Expressif.$($TextInfo.ToTitleCase($class))s.Introspection.$($TextInfo.ToTitleCase($class))Introspector"
-        $functions = $locator.Locate() | Sort-Object ListingPriority | Select-Object -Property Name, IsPublic, Aliases, Scope, Summary, Parameters
+        $functions = $locator.Describe() | Sort-Object ListingPriority | Select-Object -Property Name, IsPublic, Aliases, Scope, Summary, Parameters
         Write-Host  "`t$($functions.Count) $($class.ToLower()) identified"
         $functions | ForEach-Object {
             if ($_.IsPublic) {


### PR DESCRIPTION
Valid for Operator, Function, Predicate
Speed up the process when using the method Locate()
Use Describe() instead of Locate() to also read XML comments