### PR TITLE
fix: restore some missing aliases for all types

### DIFF
--- a/Expressif.Testing/ExpressionTest.cs
+++ b/Expressif.Testing/ExpressionTest.cs
@@ -70,7 +70,7 @@ public class ExpressionTest
     }
 
     [Test]
-    public void Evaluate_Synonyms_Valid()
+    public void Evaluate_AliasesPrefix_Valid()
     {
         var context = new Context();
         context.CurrentObject.Set(new List<char>() { 'e', 's' });
@@ -78,6 +78,25 @@ public class ExpressionTest
         var expression = new Expression("text-to-lower | text-to-remove-chars(#1)", context);
         var result = expression.Evaluate("Nikola Tesla");
         Assert.That(result, Is.EqualTo("nikola tela"));
+    }
+
+    [Test]
+    public void Evaluate_AliasesDateTime_Valid()
+    {
+        var expression = new Expression("dateTime-to-add(04:00:00, 4)", new Context());
+        var result = expression.Evaluate("2023-12-28 02:00:00");
+        Assert.That(result, Is.EqualTo(DateTime.Parse("2023-12-28 18:00:00")));
+    }
+
+    [Test]
+    [TestCase("null-to-empty | count-chars")]
+    [TestCase("null-to-empty | text-to-length")]
+    [TestCase("null-to-empty | length")]
+    public void Evaluate_AliasesAllStyles_Valid(string code)
+    {
+        var expression = new Expression(code, new Context());
+        var result = expression.Evaluate("foo");
+        Assert.That(result, Is.EqualTo(3));
     }
 
     [Test]

--- a/Expressif/Functions/BaseTypeMapper.cs
+++ b/Expressif/Functions/BaseTypeMapper.cs
@@ -14,6 +14,7 @@ public abstract class BaseTypeMapper
     public Type Execute(string functionName)
     {
         var name = functionName.ToKebabCase();
+        name = name.Replace("date-time", "dateTime");
         if (!Mapping.TryGetValue(name, out var value))
             throw new NotImplementedFunctionException(functionName);
         return value;

--- a/Expressif/Functions/Text/CountingFunctions.cs
+++ b/Expressif/Functions/Text/CountingFunctions.cs
@@ -18,7 +18,7 @@ public abstract class BaseTextCountingFunction : BaseTextFunction
 /// <summary>
 /// Returns the length of the argument value. If the value is `null` or `empty` then it returns `0`. If the value is `blank` then it returns `-1`. 
 /// </summary>
-[Function(prefix: "", aliases: ["count-chars"])]
+[Function(aliases: ["count-chars"])]
 public class Length : BaseTextCountingFunction
 {
     protected override object EvaluateSpecial(string value) => -1;

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ Install-Package Expressif
 |Text     | first-chars                | text-to-first-chars                                                              |
 |Text     | html-to-text               |                                                                                  |
 |Text     | last-chars                 | text-to-last-chars                                                               |
-|Text     | length                     | count-chars                                                                      |
+|Text     | length                     | text-to-length, count-chars                                                      |
 |Text     | lower                      | text-to-lower                                                                    |
 |Text     | mask-to-text               |                                                                                  |
 |Text     | null-to-empty              |                                                                                  |

--- a/docs/_data/function.json
+++ b/docs/_data/function.json
@@ -948,6 +948,7 @@
     "Name": "length",
     "IsPublic": true,
     "Aliases": [
+      "text-to-length",
       "count-chars"
     ],
     "Scope": "Text",


### PR DESCRIPTION
* dateTime prefix incorrectly cased date-time
* text-to-length excluded of valid aliases