### PR TITLE
build: workflow does not contain permissions

### DIFF
--- a/.github/workflows/combine-prs.yml
+++ b/.github/workflows/combine-prs.yml
@@ -21,6 +21,10 @@ on:
         required: true
         default: 'nocombine'
 
+permissions:
+  contents: write
+  pull-requests: write
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "combine-prs"


### PR DESCRIPTION
Potential fix for [https://github.com/Seddryck/Expressif/security/code-scanning/1](https://github.com/Seddryck/Expressif/security/code-scanning/1)

Add an explicit `permissions` block so the workflow token gets only the scopes needed by this job.

Best fix (without changing behavior): define permissions at the workflow root (applies to all jobs unless overridden). For this workflow, required writes are:
- `contents: write` (create branch ref and merge operations)
- `pull-requests: write` (create the combined PR)

Edit `.github/workflows/combine-prs.yml` by inserting the permissions block between the `on:` section and `jobs:` section. No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
