### PR TITLE
feat(cli): load an expression from a file and support closed expressions

### DIFF
--- a/Expressif.Cli.Tests/CliCommandTests.cs
+++ b/Expressif.Cli.Tests/CliCommandTests.cs
@@ -11,7 +11,10 @@ public class CliCommandTests
     public void TearDown()
     {
         EvaluateCommand.BuildExpression = static (code, context) => new Expression(code, context);
+        EvaluateCommand.BuildClosedExpression = static (code, context) => new ClosedExpression(code, context);
+        EvaluateCommand.EvaluateClosedExpression = static expression => expression.Evaluate();
         ValidateCommand.BuildExpression = static (code, context) => new Expression(code, context);
+        ValidateCommand.BuildClosedExpression = static (code, context) => new ClosedExpression(code, context);
 
         foreach (var path in tempFilesToDelete)
         {
@@ -36,9 +39,9 @@ public class CliCommandTests
     }
 
     [Test]
-    public async Task Evaluate_NullInput_ReturnsExpectedResult()
+    public async Task Evaluate_EmptyStringInput_ReturnsExpectedResult()
     {
-        var result = await InvokeAsync("evaluate", "null-to-empty | count-chars");
+        var result = await InvokeAsync("evaluate", "null-to-empty | count-chars", "--input", string.Empty);
 
         Assert.Multiple(() =>
         {
@@ -57,6 +60,105 @@ public class CliCommandTests
         {
             Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.Success));
             Assert.That(result.StdOut.Trim(), Is.EqualTo("null"));
+            Assert.That(result.StdErr, Is.Empty);
+        });
+    }
+
+    [Test]
+    public async Task Evaluate_ClosedExpressionWithoutInput_EvaluatesOnce()
+    {
+        var result = await InvokeAsync("evaluate", "5 | add(3)");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.Success));
+            Assert.That(result.StdOut.Trim(), Is.EqualTo("8"));
+            Assert.That(result.StdErr, Is.Empty);
+        });
+    }
+
+    [Test]
+    public async Task Evaluate_ClosedExpressionFromFileWithoutInput_EvaluatesOnce()
+    {
+        var path = CreateTempFile("5\n| add(3)\n| multiply(2)");
+
+        var result = await InvokeAsync("evaluate", "--file", path);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.Success));
+            Assert.That(result.StdOut.Trim(), Is.EqualTo("16"));
+            Assert.That(result.StdErr, Is.Empty);
+        });
+    }
+
+    [Test]
+    public async Task Evaluate_OpenExpressionWithoutInput_ReturnsInputRequiredError()
+    {
+        var result = await InvokeAsync("evaluate", "upper");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.InvalidExpressionOrInput));
+            Assert.That(result.StdOut, Is.Empty);
+            Assert.That(result.StdErr.Trim(), Is.EqualTo("The expression cannot be evaluated without an input because it references 'upper'.\nProvide an input with --input or a source with --source."));
+        });
+    }
+
+    [Test]
+    public async Task Evaluate_ClosedExpression_UnexpectedCompileException_ReturnsUnexpectedInternalErrorExitCode()
+    {
+        EvaluateCommand.BuildClosedExpression = static (_, _) => throw new InvalidOperationException("boom closed compile");
+
+        var result = await InvokeAsync("evaluate", "5 | add(3)");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.UnexpectedInternalError));
+            Assert.That(result.StdOut, Is.Empty);
+            Assert.That(result.StdErr.Trim(), Is.EqualTo("Unexpected error: boom closed compile"));
+        });
+    }
+
+    [Test]
+    public async Task Evaluate_OpenExpression_UnexpectedCompileException_ReturnsUnexpectedInternalErrorExitCode()
+    {
+        EvaluateCommand.BuildExpression = static (_, _) => throw new InvalidOperationException("boom open compile");
+
+        var result = await InvokeAsync("evaluate", "trim | upper", "--input", "abc");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.UnexpectedInternalError));
+            Assert.That(result.StdOut, Is.Empty);
+            Assert.That(result.StdErr.Trim(), Is.EqualTo("Unexpected error: boom open compile"));
+        });
+    }
+
+    [Test]
+    public async Task Evaluate_ClosedExpression_RuntimeFailure_ReturnsEvaluationExitCode()
+    {
+        EvaluateCommand.EvaluateClosedExpression = static _ => throw new InvalidOperationException("boom closed runtime");
+
+        var result = await InvokeAsync("evaluate", "5 | add(3)");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.EvaluationFailed));
+            Assert.That(result.StdOut, Is.Empty);
+            Assert.That(result.StdErr.Trim(), Is.EqualTo("boom closed runtime"));
+        });
+    }
+
+    [Test]
+    public async Task Evaluate_ExplicitEmptyInput_UsesInputBasedEvaluation()
+    {
+        var result = await InvokeAsync("evaluate", "trim | upper", "--input", string.Empty);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.Success));
+            Assert.That(result.StdOut.Trim(), Is.EqualTo("(empty)"));
             Assert.That(result.StdErr, Is.Empty);
         });
     }
@@ -148,21 +250,6 @@ public class CliCommandTests
     }
 
     [Test]
-    public async Task Evaluate_RunAlias_LoadsExpressionFile()
-    {
-        var path = CreateTempFile("trim | upper");
-
-        var result = await InvokeAsync("run", "--file", path, "--input", "nikola");
-
-        Assert.Multiple(() =>
-        {
-            Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.Success));
-            Assert.That(result.StdOut.Trim(), Is.EqualTo("NIKOLA"));
-            Assert.That(result.StdErr, Is.Empty);
-        });
-    }
-
-    [Test]
     public async Task Evaluate_BothInlineAndExpressionFile_ReturnsClearError()
     {
         var path = CreateTempFile("trim | upper");
@@ -173,7 +260,7 @@ public class CliCommandTests
         {
             Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.InvalidExpressionOrInput));
             Assert.That(result.StdOut, Is.Empty);
-            Assert.That(result.StdErr.Trim(), Is.EqualTo("The expression cannot be provided both inline and through --expression-file."));
+            Assert.That(result.StdErr.Trim(), Is.EqualTo("The expression cannot be provided both inline and through --file."));
         });
     }
 
@@ -186,7 +273,7 @@ public class CliCommandTests
         {
             Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.InvalidExpressionOrInput));
             Assert.That(result.StdOut, Is.Empty);
-            Assert.That(result.StdErr.Trim(), Is.EqualTo("The expression must be supplied through exactly one source: inline or --expression-file."));
+            Assert.That(result.StdErr.Trim(), Is.EqualTo("The expression must be supplied through exactly one source: inline or --file."));
         });
     }
 
@@ -268,6 +355,22 @@ public class CliCommandTests
     }
 
     [Test]
+    public async Task Evaluate_ExpressionFile_AccessFailure_ReturnsClearError()
+    {
+        var path = CreateTempFile("trim | upper");
+        using var lockStream = new FileStream(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+
+        var result = await InvokeAsync("evaluate", "--file", path);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.InvalidExpressionOrInput));
+            Assert.That(result.StdOut, Is.Empty);
+            Assert.That(result.StdErr, Does.StartWith($"Expression file '{path}' could not be accessed:"));
+        });
+    }
+
+    [Test]
     public async Task Evaluate_ExpressionFile_InvalidExpression_ReturnsSourceAwareError()
     {
         var path = CreateTempFile("trim | upper)");
@@ -297,6 +400,62 @@ public class CliCommandTests
     }
 
     [Test]
+    public async Task Validate_ExpressionFile_ValidExpression_ReturnsSuccessAndMessage()
+    {
+        var path = CreateTempFile("absolute | add(5)");
+
+        var result = await InvokeAsync("validate", "--file", path);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.Success));
+            Assert.That(result.StdOut.Trim(), Is.EqualTo("Expression is valid."));
+            Assert.That(result.StdErr, Is.Empty);
+        });
+    }
+
+    [Test]
+    public async Task Validate_ExpressionFile_ValidExpressionWithShortAlias_ReturnsSuccessAndMessage()
+    {
+        var path = CreateTempFile("absolute | add(5)");
+
+        var result = await InvokeAsync("validate", "-f", path);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.Success));
+            Assert.That(result.StdOut.Trim(), Is.EqualTo("Expression is valid."));
+            Assert.That(result.StdErr, Is.Empty);
+        });
+    }
+
+    [Test]
+    public async Task Validate_OpenExpressionRequiringInput_RemainsValid()
+    {
+        var result = await InvokeAsync("validate", "upper");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.Success));
+            Assert.That(result.StdOut.Trim(), Is.EqualTo("Expression is valid."));
+            Assert.That(result.StdErr, Is.Empty);
+        });
+    }
+
+    [Test]
+    public async Task Validate_OpenOption_OpenExpressionRequiringInput_RemainsValid()
+    {
+        var result = await InvokeAsync("validate", "upper", "--open");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.Success));
+            Assert.That(result.StdOut.Trim(), Is.EqualTo("Expression is valid."));
+            Assert.That(result.StdErr, Is.Empty);
+        });
+    }
+
+    [Test]
     public async Task Validate_InvalidExpression_ReturnsValidationExitCode()
     {
         var result = await InvokeAsync("validate", "absolute | unknown(5)");
@@ -306,6 +465,93 @@ public class CliCommandTests
             Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.InvalidExpressionOrInput));
             Assert.That(result.StdOut, Is.Empty);
             Assert.That(result.StdErr.Trim(), Is.EqualTo("Unknown function 'unknown'."));
+        });
+    }
+
+    [Test]
+    public async Task Validate_ExpressionFile_InvalidExpression_ReturnsSourceAwareError()
+    {
+        var path = CreateTempFile("absolute | unknown(5)");
+
+        var result = await InvokeAsync("validate", "--file", path);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.InvalidExpressionOrInput));
+            Assert.That(result.StdOut, Is.Empty);
+            Assert.That(result.StdErr, Does.Contain($"The expression loaded from '{path}' is invalid:"));
+            Assert.That(result.StdErr, Does.Contain("Unknown function 'unknown'."));
+        });
+    }
+
+    [Test]
+    public async Task Validate_DefaultOpen_IgnoresClosedValidationHook()
+    {
+        ValidateCommand.BuildClosedExpression = static (_, _) => throw new NotImplementedFunctionException("close-only-unknown");
+
+        var result = await InvokeAsync("validate", "absolute | add(5)");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.Success));
+            Assert.That(result.StdOut.Trim(), Is.EqualTo("Expression is valid."));
+            Assert.That(result.StdErr, Is.Empty);
+        });
+    }
+
+    [Test]
+    public async Task Validate_ClosedValidationError_WithClosedOption_ReturnsValidationExitCode()
+    {
+        ValidateCommand.BuildClosedExpression = static (_, _) => throw new NotImplementedFunctionException("close-only-unknown");
+
+        var result = await InvokeAsync("validate", "absolute | add(5)", "--closed");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.InvalidExpressionOrInput));
+            Assert.That(result.StdOut, Is.Empty);
+            Assert.That(result.StdErr.Trim(), Is.EqualTo("Unknown function 'close-only-unknown'."));
+        });
+    }
+
+    [Test]
+    public async Task Validate_ClosedValidationUnexpectedException_WithClosedOption_ReturnsUnexpectedInternalErrorExitCode()
+    {
+        ValidateCommand.BuildClosedExpression = static (_, _) => throw new InvalidOperationException("boom validate closed");
+
+        var result = await InvokeAsync("validate", "absolute | add(5)", "--closed");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.UnexpectedInternalError));
+            Assert.That(result.StdOut, Is.Empty);
+            Assert.That(result.StdErr.Trim(), Is.EqualTo("Unexpected error: boom validate closed"));
+        });
+    }
+
+    [Test]
+    public async Task Validate_ClosedOption_OpenExpression_ReturnsInputRequiredError()
+    {
+        var result = await InvokeAsync("validate", "upper", "--closed");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.InvalidExpressionOrInput));
+            Assert.That(result.StdOut, Is.Empty);
+            Assert.That(result.StdErr.Trim(), Is.EqualTo("The expression cannot be evaluated without an input because it references 'upper'.\nProvide an input with --input or a source with --source."));
+        });
+    }
+
+    [Test]
+    public async Task Validate_OpenAndClosedFlagsTogether_ReturnsClearError()
+    {
+        var result = await InvokeAsync("validate", "absolute | add(5)", "--open", "--closed");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.InvalidExpressionOrInput));
+            Assert.That(result.StdOut, Is.Empty);
+            Assert.That(result.StdErr.Trim(), Is.EqualTo("Options --open and --closed cannot be used together."));
         });
     }
 
@@ -348,7 +594,37 @@ public class CliCommandTests
         Assert.Multiple(() =>
         {
             Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.InvalidExpressionOrInput));
-            Assert.That(result.StdErr, Is.Not.Empty);
+            Assert.That(result.StdErr.Trim(), Is.EqualTo("The expression must be supplied through exactly one source: inline or --file."));
+        });
+    }
+
+    [Test]
+    public async Task Validate_BothInlineAndExpressionFile_ReturnsClearError()
+    {
+        var path = CreateTempFile("absolute | add(5)");
+
+        var result = await InvokeAsync("validate", "absolute | add(5)", "--file", path);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.InvalidExpressionOrInput));
+            Assert.That(result.StdOut, Is.Empty);
+            Assert.That(result.StdErr.Trim(), Is.EqualTo("The expression cannot be provided both inline and through --file."));
+        });
+    }
+
+    [Test]
+    public async Task Validate_ExpressionFile_NotFound_ReturnsClearError()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"expressif-validate-missing-{Guid.NewGuid():N}.expr");
+
+        var result = await InvokeAsync("validate", "--file", path);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.InvalidExpressionOrInput));
+            Assert.That(result.StdOut, Is.Empty);
+            Assert.That(result.StdErr.Trim(), Is.EqualTo($"Expression file '{path}' was not found."));
         });
     }
 

--- a/Expressif.Cli.Tests/CliCommandTests.cs
+++ b/Expressif.Cli.Tests/CliCommandTests.cs
@@ -5,11 +5,21 @@ namespace Expressif.Cli.Tests;
 [NonParallelizable]
 public class CliCommandTests
 {
+    private readonly List<string> tempFilesToDelete = [];
+
     [TearDown]
     public void TearDown()
     {
         EvaluateCommand.BuildExpression = static (code, context) => new Expression(code, context);
         ValidateCommand.BuildExpression = static (code, context) => new Expression(code, context);
+
+        foreach (var path in tempFilesToDelete)
+        {
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+
+        tempFilesToDelete.Clear();
     }
 
     [Test]
@@ -61,6 +71,215 @@ public class CliCommandTests
             Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.EvaluationFailed));
             Assert.That(result.StdOut, Is.Empty);
             Assert.That(result.StdErr, Is.Not.Empty);
+        });
+    }
+
+    [Test]
+    public async Task Evaluate_ExpressionFile_ProducesSameResultAsInlineExpression()
+    {
+        var path = CreateTempFile("trim\n| upper\n");
+
+        var result = await InvokeAsync("evaluate", "--file", path, "--input", "  nikola tesla  ");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.Success));
+            Assert.That(result.StdOut.Trim(), Is.EqualTo("NIKOLA TESLA"));
+            Assert.That(result.StdErr, Is.Empty);
+        });
+    }
+
+    [Test]
+    public async Task Evaluate_ExpressionFile_WithUtf8Bom_IsSupported()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"expressif-bom-{Guid.NewGuid():N}.expr");
+        File.WriteAllText(path, "trim | upper", new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: true));
+
+        try
+        {
+            var result = await InvokeAsync("evaluate", "--file", path, "--input", "nikola");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.Success));
+                Assert.That(result.StdOut.Trim(), Is.EqualTo("NIKOLA"));
+                Assert.That(result.StdErr, Is.Empty);
+            });
+        }
+        finally
+        {
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+    }
+
+    [Test]
+    public async Task Evaluate_ExpressionFile_RelativePath_IsResolvedFromCurrentDirectory()
+    {
+        var tempDirectory = Path.Combine(Path.GetTempPath(), $"expressif-cwd-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDirectory);
+
+        var originalDirectory = Directory.GetCurrentDirectory();
+        try
+        {
+            var expressionDirectory = Path.Combine(tempDirectory, "expressions");
+            Directory.CreateDirectory(expressionDirectory);
+
+            var expressionPath = Path.Combine(expressionDirectory, "transform.expr");
+            File.WriteAllText(expressionPath, "trim | upper");
+
+            Directory.SetCurrentDirectory(tempDirectory);
+
+            var result = await InvokeAsync("evaluate", "--file", Path.Combine("expressions", "transform.expr"), "--input", "nikola");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.Success));
+                Assert.That(result.StdOut.Trim(), Is.EqualTo("NIKOLA"));
+                Assert.That(result.StdErr, Is.Empty);
+            });
+        }
+        finally
+        {
+            Directory.SetCurrentDirectory(originalDirectory);
+            if (Directory.Exists(tempDirectory))
+                Directory.Delete(tempDirectory, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task Evaluate_RunAlias_LoadsExpressionFile()
+    {
+        var path = CreateTempFile("trim | upper");
+
+        var result = await InvokeAsync("run", "--file", path, "--input", "nikola");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.Success));
+            Assert.That(result.StdOut.Trim(), Is.EqualTo("NIKOLA"));
+            Assert.That(result.StdErr, Is.Empty);
+        });
+    }
+
+    [Test]
+    public async Task Evaluate_BothInlineAndExpressionFile_ReturnsClearError()
+    {
+        var path = CreateTempFile("trim | upper");
+
+        var result = await InvokeAsync("evaluate", "name | upper", "--file", path);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.InvalidExpressionOrInput));
+            Assert.That(result.StdOut, Is.Empty);
+            Assert.That(result.StdErr.Trim(), Is.EqualTo("The expression cannot be provided both inline and through --expression-file."));
+        });
+    }
+
+    [Test]
+    public async Task Evaluate_MissingInlineAndExpressionFile_ReturnsClearError()
+    {
+        var result = await InvokeAsync("evaluate");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.InvalidExpressionOrInput));
+            Assert.That(result.StdOut, Is.Empty);
+            Assert.That(result.StdErr.Trim(), Is.EqualTo("The expression must be supplied through exactly one source: inline or --expression-file."));
+        });
+    }
+
+    [Test]
+    public async Task Evaluate_ExpressionFile_NotFound_ReturnsClearError()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"expressif-missing-{Guid.NewGuid():N}.expr");
+        var result = await InvokeAsync("evaluate", "--file", path);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.InvalidExpressionOrInput));
+            Assert.That(result.StdOut, Is.Empty);
+            Assert.That(result.StdErr.Trim(), Is.EqualTo($"Expression file '{path}' was not found."));
+        });
+    }
+
+    [Test]
+    public async Task Evaluate_ExpressionFile_IsDirectory_ReturnsClearError()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"expressif-dir-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+
+        try
+        {
+            var result = await InvokeAsync("evaluate", "--file", path);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.InvalidExpressionOrInput));
+                Assert.That(result.StdOut, Is.Empty);
+                Assert.That(result.StdErr.Trim(), Is.EqualTo($"Expression file '{path}' is a directory."));
+            });
+        }
+        finally
+        {
+            if (Directory.Exists(path))
+                Directory.Delete(path, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task Evaluate_ExpressionFile_Empty_ReturnsClearError()
+    {
+        var path = CreateTempFile(" \r\n\t ");
+
+        var result = await InvokeAsync("evaluate", "--file", path);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.InvalidExpressionOrInput));
+            Assert.That(result.StdOut, Is.Empty);
+            Assert.That(result.StdErr.Trim(), Is.EqualTo($"Expression file '{path}' is empty."));
+        });
+    }
+
+    [Test]
+    public async Task Evaluate_ExpressionFile_InvalidUtf8_ReturnsClearError()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"expressif-invalid-utf8-{Guid.NewGuid():N}.expr");
+        File.WriteAllBytes(path, [0xC3, 0x28]);
+
+        try
+        {
+            var result = await InvokeAsync("evaluate", "--file", path);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.InvalidExpressionOrInput));
+                Assert.That(result.StdOut, Is.Empty);
+                Assert.That(result.StdErr.Trim(), Is.EqualTo($"Expression file '{path}' could not be decoded as UTF-8."));
+            });
+        }
+        finally
+        {
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+    }
+
+    [Test]
+    public async Task Evaluate_ExpressionFile_InvalidExpression_ReturnsSourceAwareError()
+    {
+        var path = CreateTempFile("trim | upper)");
+
+        var result = await InvokeAsync("evaluate", "--file", path);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.InvalidExpressionOrInput));
+            Assert.That(result.StdOut, Is.Empty);
+            Assert.That(result.StdErr, Does.Contain($"The expression loaded from '{path}' is invalid:"));
+            Assert.That(result.StdErr, Does.Match("(?i)line"));
         });
     }
 
@@ -181,6 +400,14 @@ public class CliCommandTests
             Console.SetOut(originalOut);
             Console.SetError(originalError);
         }
+    }
+
+    private string CreateTempFile(string content)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"expressif-{Guid.NewGuid():N}.expr");
+        File.WriteAllText(path, content, new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+        tempFilesToDelete.Add(path);
+        return path;
     }
 
     private sealed record InvocationResult(int ExitCode, string StdOut, string StdErr);

--- a/Expressif.Cli.Tests/CliCommandTests.cs
+++ b/Expressif.Cli.Tests/CliCommandTests.cs
@@ -101,7 +101,26 @@ public class CliCommandTests
         {
             Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.InvalidExpressionOrInput));
             Assert.That(result.StdOut, Is.Empty);
-            Assert.That(result.StdErr.Trim(), Is.EqualTo("The expression cannot be evaluated without an input because it references 'upper'.\nProvide an input with --input or a source with --source."));
+            Assert.That(result.StdErr, Does.Contain("The expression is valid, but it requires an input to be evaluated."));
+            Assert.That(result.StdErr, Does.Contain("The expression cannot be evaluated without an input because it references 'upper'."));
+            Assert.That(result.StdErr, Does.Contain("Provide an input with --input. You can load the expression from a file with --file."));
+        });
+    }
+
+    [Test]
+    public async Task Evaluate_ClosedEvaluationInputRequired_ButInvalidOpenExpression_ReturnsValidationError()
+    {
+        EvaluateCommand.BuildClosedExpression = static (_, _) => throw new ExpressionRequiresInputException("upper");
+        EvaluateCommand.BuildExpression = static (_, _) => throw new NotImplementedFunctionException("unknown");
+
+        var result = await InvokeAsync("evaluate", "upper");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.InvalidExpressionOrInput));
+            Assert.That(result.StdOut, Is.Empty);
+            Assert.That(result.StdErr, Does.Not.Contain("The expression is valid, but it requires an input to be evaluated."));
+            Assert.That(result.StdErr, Does.Contain("unknown"));
         });
     }
 
@@ -538,7 +557,7 @@ public class CliCommandTests
         {
             Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.InvalidExpressionOrInput));
             Assert.That(result.StdOut, Is.Empty);
-            Assert.That(result.StdErr.Trim(), Is.EqualTo("The expression cannot be evaluated without an input because it references 'upper'.\nProvide an input with --input or a source with --source."));
+            Assert.That(result.StdErr.Trim(), Is.EqualTo("The expression cannot be evaluated without an input because it references 'upper'."));
         });
     }
 

--- a/Expressif.Cli.Tests/Expressif.Cli.Tests.csproj
+++ b/Expressif.Cli.Tests/Expressif.Cli.Tests.csproj
@@ -14,7 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit.Analyzers" Version="4.14.0">
       <PrivateAssets>all</PrivateAssets>
@@ -26,7 +26,10 @@
     <PackageReference Include="NunitXml.TestLogger" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-cmhx-cq75-c4mj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Expressif.Cli/Commands/CommandErrorFormatter.cs
+++ b/Expressif.Cli/Commands/CommandErrorFormatter.cs
@@ -5,32 +5,28 @@ namespace Expressif.Cli.Commands;
 
 internal static partial class CommandErrorFormatter
 {
-    public static int WriteValidationError(Exception exception)
+    public static string FormatValidationError(Exception exception)
     {
         if (exception is ParseException)
-        {
-            Console.Error.WriteLine(exception.Message);
-            return ExitCodes.InvalidExpressionOrInput;
-        }
+            return exception.Message;
 
         if (exception is NotImplementedFunctionException)
         {
             var name = TryExtractQuotedValue(exception.Message);
-            if (string.IsNullOrEmpty(name))
-                Console.Error.WriteLine(exception.Message);
-            else
-                Console.Error.WriteLine($"Unknown function '{name}'.");
-
-            return ExitCodes.InvalidExpressionOrInput;
+            return string.IsNullOrEmpty(name)
+                ? exception.Message
+                : $"Unknown function '{name}'.";
         }
 
         if (exception is MissingOrUnexpectedParametersFunctionException)
-        {
-            Console.Error.WriteLine(exception.Message);
-            return ExitCodes.InvalidExpressionOrInput;
-        }
+            return exception.Message;
 
-        Console.Error.WriteLine(exception.Message);
+        return exception.Message;
+    }
+
+    public static int WriteValidationError(Exception exception)
+    {
+        Console.Error.WriteLine(FormatValidationError(exception));
         return ExitCodes.InvalidExpressionOrInput;
     }
 

--- a/Expressif.Cli/Commands/CommandErrorFormatter.cs
+++ b/Expressif.Cli/Commands/CommandErrorFormatter.cs
@@ -7,9 +7,6 @@ internal static partial class CommandErrorFormatter
 {
     public static string FormatValidationError(Exception exception)
     {
-        if (exception is ParseException)
-            return exception.Message;
-
         if (exception is NotImplementedFunctionException)
         {
             var name = TryExtractQuotedValue(exception.Message);
@@ -17,9 +14,6 @@ internal static partial class CommandErrorFormatter
                 ? exception.Message
                 : $"Unknown function '{name}'.";
         }
-
-        if (exception is MissingOrUnexpectedParametersFunctionException)
-            return exception.Message;
 
         return exception.Message;
     }

--- a/Expressif.Cli/Commands/EvaluateCommand.cs
+++ b/Expressif.Cli/Commands/EvaluateCommand.cs
@@ -55,51 +55,81 @@ internal static class EvaluateCommand
                 return ExitCodes.InvalidExpressionOrInput;
             }
 
-            var useClosedEvaluation = !hasInputOption;
+            if (!hasInputOption)
+                return EvaluateClosed(expressionCode, hasExpressionFile, expressionFilePath);
 
-            if (useClosedEvaluation)
-            {
-                ClosedExpression closedExpression;
-                try
-                {
-                    closedExpression = BuildClosedExpression(expressionCode, new Context());
-                }
-                catch (ExpressionRequiresInputException exception)
-                {
-                    Console.Error.WriteLine(exception.Message);
-                    return ExitCodes.InvalidExpressionOrInput;
-                }
-                catch (Exception exception) when (exception is Sprache.ParseException
-                                                  or NotImplementedFunctionException
-                                                  or MissingOrUnexpectedParametersFunctionException)
-                {
-                    return ExpressionCommandCommon.WriteValidationError(exception, hasExpressionFile, expressionFilePath);
-                }
-                catch (Exception exception)
-                {
-                    Console.Error.WriteLine($"Unexpected error: {exception.Message}");
-                    return ExitCodes.UnexpectedInternalError;
-                }
+            return EvaluateOpen(expressionCode, input, hasExpressionFile, expressionFilePath);
+        });
 
-                try
-                {
-                    var result = EvaluateClosedExpression(closedExpression);
-                    Console.Out.WriteLine(result ?? "null");
-                    return ExitCodes.Success;
-                }
-                catch (ExpressionRequiresInputException exception)
-                {
-                    Console.Error.WriteLine(exception.Message);
-                    return ExitCodes.InvalidExpressionOrInput;
-                }
-                catch (Exception exception) when (exception is not OutOfMemoryException)
-                {
-                    Console.Error.WriteLine(exception.Message);
-                    return ExitCodes.EvaluationFailed;
-                }
-            }
+        return command;
+    }
 
-            Expressif.Expression openExpression;
+    private static int EvaluateClosed(string expressionCode, bool hasExpressionFile, string? expressionFilePath)
+    {
+        ClosedExpression closedExpression;
+        try
+        {
+            closedExpression = BuildClosedExpression(expressionCode, new Context());
+        }
+        catch (ExpressionRequiresInputException exception)
+        {
+            var openValidationResult = ValidateAsOpenExpression(expressionCode, hasExpressionFile, expressionFilePath);
+            if (openValidationResult != ExitCodes.Success)
+                return openValidationResult;
+
+            Console.Error.WriteLine("The expression is valid, but it requires an input to be evaluated.");
+            Console.Error.WriteLine(exception.Message);
+            Console.Error.WriteLine("Provide an input with --input. You can load the expression from a file with --file.");
+            return ExitCodes.InvalidExpressionOrInput;
+        }
+        catch (Exception exception) when (exception is Sprache.ParseException
+                                          or NotImplementedFunctionException
+                                          or MissingOrUnexpectedParametersFunctionException)
+        {
+            return ExpressionCommandCommon.WriteValidationError(exception, hasExpressionFile, expressionFilePath);
+        }
+        catch (Exception exception)
+        {
+            Console.Error.WriteLine($"Unexpected error: {exception.Message}");
+            return ExitCodes.UnexpectedInternalError;
+        }
+
+        try
+        {
+            var result = EvaluateClosedExpression(closedExpression);
+            Console.Out.WriteLine(result ?? "null");
+            return ExitCodes.Success;
+        }
+        catch (Exception exception) when (exception is not OutOfMemoryException)
+        {
+            Console.Error.WriteLine(exception.Message);
+            return ExitCodes.EvaluationFailed;
+        }
+    }
+
+    private static int ValidateAsOpenExpression(string expressionCode, bool hasExpressionFile, string? expressionFilePath)
+    {
+        try
+        {
+            _ = BuildExpression(expressionCode, new Context());
+            return ExitCodes.Success;
+        }
+        catch (Exception exception) when (exception is Sprache.ParseException
+                                          or NotImplementedFunctionException
+                                          or MissingOrUnexpectedParametersFunctionException)
+        {
+            return ExpressionCommandCommon.WriteValidationError(exception, hasExpressionFile, expressionFilePath);
+        }
+        catch (Exception exception)
+        {
+            Console.Error.WriteLine($"Unexpected error: {exception.Message}");
+            return ExitCodes.UnexpectedInternalError;
+        }
+    }
+
+    private static int EvaluateOpen(string expressionCode, string? input, bool hasExpressionFile, string? expressionFilePath)
+    {
+        Expressif.Expression openExpression;
             try
             {
                 openExpression = BuildExpression(expressionCode, new Context());
@@ -127,8 +157,5 @@ internal static class EvaluateCommand
                 Console.Error.WriteLine(exception.Message);
                 return ExitCodes.EvaluationFailed;
             }
-        });
-
-        return command;
     }
 }

--- a/Expressif.Cli/Commands/EvaluateCommand.cs
+++ b/Expressif.Cli/Commands/EvaluateCommand.cs
@@ -1,4 +1,5 @@
 using System.CommandLine;
+using System.Text;
 
 namespace Expressif.Cli.Commands;
 
@@ -9,8 +10,9 @@ internal static class EvaluateCommand
 
     public static Command Create()
     {
-        var expressionArgument = new Argument<string>("expression")
+        var expressionArgument = new Argument<string?>("expression")
         {
+            Arity = ArgumentArity.ZeroOrOne,
             Description = "Expression to evaluate."
         };
 
@@ -20,15 +22,46 @@ internal static class EvaluateCommand
         };
         inputOption.Aliases.Add("-i");
 
+        var expressionFileOption = new Option<string?>("--file")
+        {
+            Description = "Path to a UTF-8 file containing the expression to evaluate."
+        };
+        expressionFileOption.Aliases.Add("-f");
+        expressionFileOption.Aliases.Add("--expression-file");
+
         var command = new Command("evaluate", "Evaluate an Expressif expression.");
+        command.Aliases.Add("run");
 
         command.Arguments.Add(expressionArgument);
         command.Options.Add(inputOption);
+        command.Options.Add(expressionFileOption);
 
         command.SetAction(parseResult =>
         {
             var expressionCode = parseResult.GetValue(expressionArgument);
+            var expressionFilePath = parseResult.GetValue(expressionFileOption);
             var input = parseResult.GetValue(inputOption);
+
+            var hasInlineExpression = !string.IsNullOrWhiteSpace(expressionCode);
+            var hasExpressionFile = !string.IsNullOrWhiteSpace(expressionFilePath);
+
+            if (hasInlineExpression && hasExpressionFile)
+            {
+                Console.Error.WriteLine("The expression cannot be provided both inline and through --expression-file.");
+                return ExitCodes.InvalidExpressionOrInput;
+            }
+
+            if (!hasInlineExpression && !hasExpressionFile)
+            {
+                Console.Error.WriteLine("The expression must be supplied through exactly one source: inline or --expression-file.");
+                return ExitCodes.InvalidExpressionOrInput;
+            }
+
+            if (hasExpressionFile
+                && !TryReadExpressionFile(expressionFilePath!, out expressionCode))
+            {
+                return ExitCodes.InvalidExpressionOrInput;
+            }
 
             if (string.IsNullOrWhiteSpace(expressionCode))
             {
@@ -45,6 +78,13 @@ internal static class EvaluateCommand
                                               or NotImplementedFunctionException
                                               or MissingOrUnexpectedParametersFunctionException)
             {
+                if (hasExpressionFile)
+                {
+                    Console.Error.WriteLine($"The expression loaded from '{expressionFilePath}' is invalid:");
+                    Console.Error.WriteLine(CommandErrorFormatter.FormatValidationError(exception));
+                    return ExitCodes.InvalidExpressionOrInput;
+                }
+
                 return CommandErrorFormatter.WriteValidationError(exception);
             }
             catch (Exception exception)
@@ -67,5 +107,47 @@ internal static class EvaluateCommand
         });
 
         return command;
+    }
+
+    private static bool TryReadExpressionFile(string path, out string expressionCode)
+    {
+        expressionCode = string.Empty;
+
+        if (Directory.Exists(path))
+        {
+            Console.Error.WriteLine($"Expression file '{path}' is a directory.");
+            return false;
+        }
+
+        if (!File.Exists(path))
+        {
+            Console.Error.WriteLine($"Expression file '{path}' was not found.");
+            return false;
+        }
+
+        try
+        {
+            using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+            using var reader = new StreamReader(stream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true), detectEncodingFromByteOrderMarks: true);
+            expressionCode = reader.ReadToEnd();
+        }
+        catch (DecoderFallbackException)
+        {
+            Console.Error.WriteLine($"Expression file '{path}' could not be decoded as UTF-8.");
+            return false;
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            Console.Error.WriteLine($"Expression file '{path}' could not be accessed: {exception.Message}");
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(expressionCode))
+        {
+            Console.Error.WriteLine($"Expression file '{path}' is empty.");
+            return false;
+        }
+
+        return true;
     }
 }

--- a/Expressif.Cli/Commands/EvaluateCommand.cs
+++ b/Expressif.Cli/Commands/EvaluateCommand.cs
@@ -8,6 +8,12 @@ internal static class EvaluateCommand
     internal static Func<string, Context, Expression> BuildExpression { get; set; }
         = static (code, context) => new Expression(code, context);
 
+    internal static Func<string, Context, ClosedExpression> BuildClosedExpression { get; set; }
+        = static (code, context) => new ClosedExpression(code, context);
+
+    internal static Func<ClosedExpression, object?> EvaluateClosedExpression { get; set; }
+        = static expression => expression.Evaluate();
+
     public static Command Create()
     {
         var expressionArgument = new Argument<string?>("expression")
@@ -27,10 +33,8 @@ internal static class EvaluateCommand
             Description = "Path to a UTF-8 file containing the expression to evaluate."
         };
         expressionFileOption.Aliases.Add("-f");
-        expressionFileOption.Aliases.Add("--expression-file");
 
         var command = new Command("evaluate", "Evaluate an Expressif expression.");
-        command.Aliases.Add("run");
 
         command.Arguments.Add(expressionArgument);
         command.Options.Add(inputOption);
@@ -41,19 +45,20 @@ internal static class EvaluateCommand
             var expressionCode = parseResult.GetValue(expressionArgument);
             var expressionFilePath = parseResult.GetValue(expressionFileOption);
             var input = parseResult.GetValue(inputOption);
+            var hasInputOption = parseResult.GetResult(inputOption) is not null;
 
             var hasInlineExpression = !string.IsNullOrWhiteSpace(expressionCode);
             var hasExpressionFile = !string.IsNullOrWhiteSpace(expressionFilePath);
 
             if (hasInlineExpression && hasExpressionFile)
             {
-                Console.Error.WriteLine("The expression cannot be provided both inline and through --expression-file.");
+                Console.Error.WriteLine("The expression cannot be provided both inline and through --file.");
                 return ExitCodes.InvalidExpressionOrInput;
             }
 
             if (!hasInlineExpression && !hasExpressionFile)
             {
-                Console.Error.WriteLine("The expression must be supplied through exactly one source: inline or --expression-file.");
+                Console.Error.WriteLine("The expression must be supplied through exactly one source: inline or --file.");
                 return ExitCodes.InvalidExpressionOrInput;
             }
 
@@ -69,10 +74,61 @@ internal static class EvaluateCommand
                 return ExitCodes.InvalidExpressionOrInput;
             }
 
-            Expressif.Expression expression;
+            var useClosedEvaluation = !hasInputOption;
+
+            if (useClosedEvaluation)
+            {
+                ClosedExpression closedExpression;
+                try
+                {
+                    closedExpression = BuildClosedExpression(expressionCode, new Context());
+                }
+                catch (ExpressionRequiresInputException exception)
+                {
+                    Console.Error.WriteLine(exception.Message);
+                    return ExitCodes.InvalidExpressionOrInput;
+                }
+                catch (Exception exception) when (exception is Sprache.ParseException
+                                                  or NotImplementedFunctionException
+                                                  or MissingOrUnexpectedParametersFunctionException)
+                {
+                    if (hasExpressionFile)
+                    {
+                        Console.Error.WriteLine($"The expression loaded from '{expressionFilePath}' is invalid:");
+                        Console.Error.WriteLine(CommandErrorFormatter.FormatValidationError(exception));
+                        return ExitCodes.InvalidExpressionOrInput;
+                    }
+
+                    return CommandErrorFormatter.WriteValidationError(exception);
+                }
+                catch (Exception exception)
+                {
+                    Console.Error.WriteLine($"Unexpected error: {exception.Message}");
+                    return ExitCodes.UnexpectedInternalError;
+                }
+
+                try
+                {
+                    var result = EvaluateClosedExpression(closedExpression);
+                    Console.Out.WriteLine(result ?? "null");
+                    return ExitCodes.Success;
+                }
+                catch (ExpressionRequiresInputException exception)
+                {
+                    Console.Error.WriteLine(exception.Message);
+                    return ExitCodes.InvalidExpressionOrInput;
+                }
+                catch (Exception exception) when (exception is not OutOfMemoryException)
+                {
+                    Console.Error.WriteLine(exception.Message);
+                    return ExitCodes.EvaluationFailed;
+                }
+            }
+
+            Expressif.Expression openExpression;
             try
             {
-                expression = BuildExpression(expressionCode, new Context());
+                openExpression = BuildExpression(expressionCode, new Context());
             }
             catch (Exception exception) when (exception is Sprache.ParseException
                                               or NotImplementedFunctionException
@@ -95,7 +151,7 @@ internal static class EvaluateCommand
 
             try
             {
-                var result = expression.Evaluate(input);
+                var result = openExpression.Evaluate(input);
                 Console.Out.WriteLine(result ?? "null");
                 return ExitCodes.Success;
             }

--- a/Expressif.Cli/Commands/EvaluateCommand.cs
+++ b/Expressif.Cli/Commands/EvaluateCommand.cs
@@ -1,5 +1,4 @@
 using System.CommandLine;
-using System.Text;
 
 namespace Expressif.Cli.Commands;
 
@@ -42,35 +41,17 @@ internal static class EvaluateCommand
 
         command.SetAction(parseResult =>
         {
-            var expressionCode = parseResult.GetValue(expressionArgument);
+            var inlineExpression = parseResult.GetValue(expressionArgument);
             var expressionFilePath = parseResult.GetValue(expressionFileOption);
             var input = parseResult.GetValue(inputOption);
             var hasInputOption = parseResult.GetResult(inputOption) is not null;
 
-            var hasInlineExpression = !string.IsNullOrWhiteSpace(expressionCode);
-            var hasExpressionFile = !string.IsNullOrWhiteSpace(expressionFilePath);
-
-            if (hasInlineExpression && hasExpressionFile)
+            if (!ExpressionCommandCommon.TryResolveExpressionCode(
+                    inlineExpression,
+                    expressionFilePath,
+                    out var expressionCode,
+                    out var hasExpressionFile))
             {
-                Console.Error.WriteLine("The expression cannot be provided both inline and through --file.");
-                return ExitCodes.InvalidExpressionOrInput;
-            }
-
-            if (!hasInlineExpression && !hasExpressionFile)
-            {
-                Console.Error.WriteLine("The expression must be supplied through exactly one source: inline or --file.");
-                return ExitCodes.InvalidExpressionOrInput;
-            }
-
-            if (hasExpressionFile
-                && !TryReadExpressionFile(expressionFilePath!, out expressionCode))
-            {
-                return ExitCodes.InvalidExpressionOrInput;
-            }
-
-            if (string.IsNullOrWhiteSpace(expressionCode))
-            {
-                Console.Error.WriteLine("Expression is required.");
                 return ExitCodes.InvalidExpressionOrInput;
             }
 
@@ -92,14 +73,7 @@ internal static class EvaluateCommand
                                                   or NotImplementedFunctionException
                                                   or MissingOrUnexpectedParametersFunctionException)
                 {
-                    if (hasExpressionFile)
-                    {
-                        Console.Error.WriteLine($"The expression loaded from '{expressionFilePath}' is invalid:");
-                        Console.Error.WriteLine(CommandErrorFormatter.FormatValidationError(exception));
-                        return ExitCodes.InvalidExpressionOrInput;
-                    }
-
-                    return CommandErrorFormatter.WriteValidationError(exception);
+                    return ExpressionCommandCommon.WriteValidationError(exception, hasExpressionFile, expressionFilePath);
                 }
                 catch (Exception exception)
                 {
@@ -134,14 +108,7 @@ internal static class EvaluateCommand
                                               or NotImplementedFunctionException
                                               or MissingOrUnexpectedParametersFunctionException)
             {
-                if (hasExpressionFile)
-                {
-                    Console.Error.WriteLine($"The expression loaded from '{expressionFilePath}' is invalid:");
-                    Console.Error.WriteLine(CommandErrorFormatter.FormatValidationError(exception));
-                    return ExitCodes.InvalidExpressionOrInput;
-                }
-
-                return CommandErrorFormatter.WriteValidationError(exception);
+                return ExpressionCommandCommon.WriteValidationError(exception, hasExpressionFile, expressionFilePath);
             }
             catch (Exception exception)
             {
@@ -163,47 +130,5 @@ internal static class EvaluateCommand
         });
 
         return command;
-    }
-
-    private static bool TryReadExpressionFile(string path, out string expressionCode)
-    {
-        expressionCode = string.Empty;
-
-        if (Directory.Exists(path))
-        {
-            Console.Error.WriteLine($"Expression file '{path}' is a directory.");
-            return false;
-        }
-
-        if (!File.Exists(path))
-        {
-            Console.Error.WriteLine($"Expression file '{path}' was not found.");
-            return false;
-        }
-
-        try
-        {
-            using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
-            using var reader = new StreamReader(stream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true), detectEncodingFromByteOrderMarks: true);
-            expressionCode = reader.ReadToEnd();
-        }
-        catch (DecoderFallbackException)
-        {
-            Console.Error.WriteLine($"Expression file '{path}' could not be decoded as UTF-8.");
-            return false;
-        }
-        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
-        {
-            Console.Error.WriteLine($"Expression file '{path}' could not be accessed: {exception.Message}");
-            return false;
-        }
-
-        if (string.IsNullOrWhiteSpace(expressionCode))
-        {
-            Console.Error.WriteLine($"Expression file '{path}' is empty.");
-            return false;
-        }
-
-        return true;
     }
 }

--- a/Expressif.Cli/Commands/ExpressionCommandCommon.cs
+++ b/Expressif.Cli/Commands/ExpressionCommandCommon.cs
@@ -1,0 +1,97 @@
+using System.Text;
+
+namespace Expressif.Cli.Commands;
+
+internal static class ExpressionCommandCommon
+{
+    internal static bool TryResolveExpressionCode(
+        string? inlineExpression,
+        string? expressionFilePath,
+        out string expressionCode,
+        out bool hasExpressionFile)
+    {
+        expressionCode = inlineExpression ?? string.Empty;
+        hasExpressionFile = !string.IsNullOrWhiteSpace(expressionFilePath);
+        var hasInlineExpression = !string.IsNullOrWhiteSpace(inlineExpression);
+
+        if (hasInlineExpression && hasExpressionFile)
+        {
+            Console.Error.WriteLine("The expression cannot be provided both inline and through --file.");
+            return false;
+        }
+
+        if (!hasInlineExpression && !hasExpressionFile)
+        {
+            Console.Error.WriteLine("The expression must be supplied through exactly one source: inline or --file.");
+            return false;
+        }
+
+        if (hasExpressionFile
+            && !TryReadExpressionFile(expressionFilePath!, out expressionCode))
+        {
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(expressionCode))
+        {
+            Console.Error.WriteLine("Expression is required.");
+            return false;
+        }
+
+        return true;
+    }
+
+    internal static int WriteValidationError(Exception exception, bool hasExpressionFile, string? expressionFilePath)
+    {
+        if (hasExpressionFile)
+        {
+            Console.Error.WriteLine($"The expression loaded from '{expressionFilePath}' is invalid:");
+            Console.Error.WriteLine(CommandErrorFormatter.FormatValidationError(exception));
+            return ExitCodes.InvalidExpressionOrInput;
+        }
+
+        return CommandErrorFormatter.WriteValidationError(exception);
+    }
+
+    private static bool TryReadExpressionFile(string path, out string expressionCode)
+    {
+        expressionCode = string.Empty;
+
+        if (Directory.Exists(path))
+        {
+            Console.Error.WriteLine($"Expression file '{path}' is a directory.");
+            return false;
+        }
+
+        if (!File.Exists(path))
+        {
+            Console.Error.WriteLine($"Expression file '{path}' was not found.");
+            return false;
+        }
+
+        try
+        {
+            using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+            using var reader = new StreamReader(stream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true), detectEncodingFromByteOrderMarks: true);
+            expressionCode = reader.ReadToEnd();
+        }
+        catch (DecoderFallbackException)
+        {
+            Console.Error.WriteLine($"Expression file '{path}' could not be decoded as UTF-8.");
+            return false;
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            Console.Error.WriteLine($"Expression file '{path}' could not be accessed: {exception.Message}");
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(expressionCode))
+        {
+            Console.Error.WriteLine($"Expression file '{path}' is empty.");
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/Expressif.Cli/Commands/ExpressionCommandCommon.cs
+++ b/Expressif.Cli/Commands/ExpressionCommandCommon.cs
@@ -80,7 +80,10 @@ internal static class ExpressionCommandCommon
             Console.Error.WriteLine($"Expression file '{path}' could not be decoded as UTF-8.");
             return false;
         }
-        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        catch (Exception exception) when (exception is IOException
+                                          or UnauthorizedAccessException
+                                          or ArgumentException
+                                          or NotSupportedException)
         {
             Console.Error.WriteLine($"Expression file '{path}' could not be accessed: {exception.Message}");
             return false;

--- a/Expressif.Cli/Commands/ValidateCommand.cs
+++ b/Expressif.Cli/Commands/ValidateCommand.cs
@@ -1,5 +1,4 @@
 using System.CommandLine;
-using System.Text;
 
 namespace Expressif.Cli.Commands;
 
@@ -44,7 +43,7 @@ internal static class ValidateCommand
 
         command.SetAction(parseResult =>
         {
-            var expressionCode = parseResult.GetValue(expressionArgument);
+            var inlineExpression = parseResult.GetValue(expressionArgument);
             var expressionFilePath = parseResult.GetValue(expressionFileOption);
             var asOpenExpression = parseResult.GetValue(openOption);
             var asClosedExpression = parseResult.GetValue(closedOption);
@@ -57,30 +56,12 @@ internal static class ValidateCommand
 
             var useClosedValidation = asClosedExpression;
 
-            var hasInlineExpression = !string.IsNullOrWhiteSpace(expressionCode);
-            var hasExpressionFile = !string.IsNullOrWhiteSpace(expressionFilePath);
-
-            if (hasInlineExpression && hasExpressionFile)
+            if (!ExpressionCommandCommon.TryResolveExpressionCode(
+                    inlineExpression,
+                    expressionFilePath,
+                    out var expressionCode,
+                    out var hasExpressionFile))
             {
-                Console.Error.WriteLine("The expression cannot be provided both inline and through --file.");
-                return ExitCodes.InvalidExpressionOrInput;
-            }
-
-            if (!hasInlineExpression && !hasExpressionFile)
-            {
-                Console.Error.WriteLine("The expression must be supplied through exactly one source: inline or --file.");
-                return ExitCodes.InvalidExpressionOrInput;
-            }
-
-            if (hasExpressionFile
-                && !TryReadExpressionFile(expressionFilePath!, out expressionCode))
-            {
-                return ExitCodes.InvalidExpressionOrInput;
-            }
-
-            if (string.IsNullOrWhiteSpace(expressionCode))
-            {
-                Console.Error.WriteLine("Expression is required.");
                 return ExitCodes.InvalidExpressionOrInput;
             }
 
@@ -107,14 +88,7 @@ internal static class ValidateCommand
                                               or NotImplementedFunctionException
                                               or MissingOrUnexpectedParametersFunctionException)
             {
-                if (hasExpressionFile)
-                {
-                    Console.Error.WriteLine($"The expression loaded from '{expressionFilePath}' is invalid:");
-                    Console.Error.WriteLine(CommandErrorFormatter.FormatValidationError(exception));
-                    return ExitCodes.InvalidExpressionOrInput;
-                }
-
-                return CommandErrorFormatter.WriteValidationError(exception);
+                return ExpressionCommandCommon.WriteValidationError(exception, hasExpressionFile, expressionFilePath);
             }
             catch (Exception exception)
             {
@@ -124,47 +98,5 @@ internal static class ValidateCommand
         });
 
         return command;
-    }
-
-    private static bool TryReadExpressionFile(string path, out string expressionCode)
-    {
-        expressionCode = string.Empty;
-
-        if (Directory.Exists(path))
-        {
-            Console.Error.WriteLine($"Expression file '{path}' is a directory.");
-            return false;
-        }
-
-        if (!File.Exists(path))
-        {
-            Console.Error.WriteLine($"Expression file '{path}' was not found.");
-            return false;
-        }
-
-        try
-        {
-            using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
-            using var reader = new StreamReader(stream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true), detectEncodingFromByteOrderMarks: true);
-            expressionCode = reader.ReadToEnd();
-        }
-        catch (DecoderFallbackException)
-        {
-            Console.Error.WriteLine($"Expression file '{path}' could not be decoded as UTF-8.");
-            return false;
-        }
-        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
-        {
-            Console.Error.WriteLine($"Expression file '{path}' could not be accessed: {exception.Message}");
-            return false;
-        }
-
-        if (string.IsNullOrWhiteSpace(expressionCode))
-        {
-            Console.Error.WriteLine($"Expression file '{path}' is empty.");
-            return false;
-        }
-
-        return true;
     }
 }

--- a/Expressif.Cli/Commands/ValidateCommand.cs
+++ b/Expressif.Cli/Commands/ValidateCommand.cs
@@ -1,4 +1,5 @@
 using System.CommandLine;
+using System.Text;
 
 namespace Expressif.Cli.Commands;
 
@@ -7,20 +8,75 @@ internal static class ValidateCommand
     internal static Func<string, Context, Expression> BuildExpression { get; set; }
         = static (code, context) => new Expression(code, context);
 
+    internal static Func<string, Context, ClosedExpression> BuildClosedExpression { get; set; }
+        = static (code, context) => new ClosedExpression(code, context);
+
     public static Command Create()
     {
-        var expressionArgument = new Argument<string>("expression")
+        var expressionArgument = new Argument<string?>("expression")
         {
+            Arity = ArgumentArity.ZeroOrOne,
             Description = "Expression to validate."
+        };
+
+        var expressionFileOption = new Option<string?>("--file")
+        {
+            Description = "Path to a UTF-8 file containing the expression to validate."
+        };
+        expressionFileOption.Aliases.Add("-f");
+
+        var openOption = new Option<bool>("--open")
+        {
+            Description = "Validate the expression as an open expression (default behavior)."
+        };
+
+        var closedOption = new Option<bool>("--closed")
+        {
+            Description = "Validate the expression as a closed expression."
         };
 
         var command = new Command("validate", "Validate an Expressif expression.");
 
         command.Arguments.Add(expressionArgument);
+        command.Options.Add(expressionFileOption);
+        command.Options.Add(openOption);
+        command.Options.Add(closedOption);
 
         command.SetAction(parseResult =>
         {
             var expressionCode = parseResult.GetValue(expressionArgument);
+            var expressionFilePath = parseResult.GetValue(expressionFileOption);
+            var asOpenExpression = parseResult.GetValue(openOption);
+            var asClosedExpression = parseResult.GetValue(closedOption);
+
+            if (asOpenExpression && asClosedExpression)
+            {
+                Console.Error.WriteLine("Options --open and --closed cannot be used together.");
+                return ExitCodes.InvalidExpressionOrInput;
+            }
+
+            var useClosedValidation = asClosedExpression;
+
+            var hasInlineExpression = !string.IsNullOrWhiteSpace(expressionCode);
+            var hasExpressionFile = !string.IsNullOrWhiteSpace(expressionFilePath);
+
+            if (hasInlineExpression && hasExpressionFile)
+            {
+                Console.Error.WriteLine("The expression cannot be provided both inline and through --file.");
+                return ExitCodes.InvalidExpressionOrInput;
+            }
+
+            if (!hasInlineExpression && !hasExpressionFile)
+            {
+                Console.Error.WriteLine("The expression must be supplied through exactly one source: inline or --file.");
+                return ExitCodes.InvalidExpressionOrInput;
+            }
+
+            if (hasExpressionFile
+                && !TryReadExpressionFile(expressionFilePath!, out expressionCode))
+            {
+                return ExitCodes.InvalidExpressionOrInput;
+            }
 
             if (string.IsNullOrWhiteSpace(expressionCode))
             {
@@ -30,14 +86,34 @@ internal static class ValidateCommand
 
             try
             {
-                _ = BuildExpression(expressionCode, new Context());
+                if (useClosedValidation)
+                {
+                    _ = BuildClosedExpression(expressionCode, new Context());
+                }
+                else
+                {
+                    _ = BuildExpression(expressionCode, new Context());
+                }
+
                 Console.Out.WriteLine("Expression is valid.");
                 return ExitCodes.Success;
+            }
+            catch (ExpressionRequiresInputException exception)
+            {
+                Console.Error.WriteLine(exception.Message);
+                return ExitCodes.InvalidExpressionOrInput;
             }
             catch (Exception exception) when (exception is Sprache.ParseException
                                               or NotImplementedFunctionException
                                               or MissingOrUnexpectedParametersFunctionException)
             {
+                if (hasExpressionFile)
+                {
+                    Console.Error.WriteLine($"The expression loaded from '{expressionFilePath}' is invalid:");
+                    Console.Error.WriteLine(CommandErrorFormatter.FormatValidationError(exception));
+                    return ExitCodes.InvalidExpressionOrInput;
+                }
+
                 return CommandErrorFormatter.WriteValidationError(exception);
             }
             catch (Exception exception)
@@ -48,5 +124,47 @@ internal static class ValidateCommand
         });
 
         return command;
+    }
+
+    private static bool TryReadExpressionFile(string path, out string expressionCode)
+    {
+        expressionCode = string.Empty;
+
+        if (Directory.Exists(path))
+        {
+            Console.Error.WriteLine($"Expression file '{path}' is a directory.");
+            return false;
+        }
+
+        if (!File.Exists(path))
+        {
+            Console.Error.WriteLine($"Expression file '{path}' was not found.");
+            return false;
+        }
+
+        try
+        {
+            using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+            using var reader = new StreamReader(stream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true), detectEncodingFromByteOrderMarks: true);
+            expressionCode = reader.ReadToEnd();
+        }
+        catch (DecoderFallbackException)
+        {
+            Console.Error.WriteLine($"Expression file '{path}' could not be decoded as UTF-8.");
+            return false;
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            Console.Error.WriteLine($"Expression file '{path}' could not be accessed: {exception.Message}");
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(expressionCode))
+        {
+            Console.Error.WriteLine($"Expression file '{path}' is empty.");
+            return false;
+        }
+
+        return true;
     }
 }

--- a/Expressif.Testing/ClosedExpressionTest.cs
+++ b/Expressif.Testing/ClosedExpressionTest.cs
@@ -37,6 +37,6 @@ public class ClosedExpressionTest
     {
         var exception = Assert.Throws<ExpressionRequiresInputException>(() => new ClosedExpression("upper"));
 
-        Assert.That(exception!.Message, Is.EqualTo("The expression cannot be evaluated without an input because it references 'upper'.\nProvide an input with --input or a source with --source."));
+        Assert.That(exception!.Message, Is.EqualTo("The expression cannot be evaluated without an input because it references 'upper'."));
     }
 }

--- a/Expressif.Testing/ClosedExpressionTest.cs
+++ b/Expressif.Testing/ClosedExpressionTest.cs
@@ -31,4 +31,12 @@ public class ClosedExpressionTest
         var result = expression.Evaluate();
         Assert.That(result, Is.EqualTo(7));
     }
+
+    [Test]
+    public void Evaluate_OpenExpression_ThrowsExpressionRequiresInputException()
+    {
+        var exception = Assert.Throws<ExpressionRequiresInputException>(() => new ClosedExpression("upper"));
+
+        Assert.That(exception!.Message, Is.EqualTo("The expression cannot be evaluated without an input because it references 'upper'.\nProvide an input with --input or a source with --source."));
+    }
 }

--- a/Expressif/ClosedExpression.cs
+++ b/Expressif/ClosedExpression.cs
@@ -13,7 +13,7 @@ public class ClosedExpression
         : this(code, context, new ExpressionFactory()) { }
 
     public ClosedExpression(string code, IContext context, ExpressionFactory factory)
-        => expression = factory.Instantiate(code, context);
+        => expression = factory.InstantiateClosed(code, context);
 
     public object? Evaluate()
         => expression.Evaluate(null);

--- a/Expressif/ExpressifException.cs
+++ b/Expressif/ExpressifException.cs
@@ -58,3 +58,12 @@ public class NotNameableContextObjectException : ExpressifException
         : base($"The current object of the context of type '{value?.GetType().Name ?? "null"}' is not being accessible with properties' name.")
     { }
 }
+
+public class ExpressionRequiresInputException : ExpressifException
+{
+    public ExpressionRequiresInputException(string? reference)
+        : base(reference is null
+            ? "The expression is valid but requires an input.\nProvide a value with --input or a file with --source."
+            : $"The expression cannot be evaluated without an input because it references '{reference}'.\nProvide an input with --input or a source with --source.")
+    { }
+}

--- a/Expressif/ExpressifException.cs
+++ b/Expressif/ExpressifException.cs
@@ -63,7 +63,7 @@ public class ExpressionRequiresInputException : ExpressifException
 {
     public ExpressionRequiresInputException(string? reference)
         : base(reference is null
-            ? "The expression is valid but requires an input.\nProvide a value with --input or a file with --source."
-            : $"The expression cannot be evaluated without an input because it references '{reference}'.\nProvide an input with --input or a source with --source.")
+            ? "The expression is valid but requires an input to be evaluated."
+            : $"The expression cannot be evaluated without an input because it references '{reference}'.")
     { }
 }

--- a/Expressif/Functions/ExpressionFactory.cs
+++ b/Expressif/Functions/ExpressionFactory.cs
@@ -24,7 +24,7 @@ public class ExpressionFactory : BaseExpressionFactory
 
     public IFunction Instantiate(string code, IContext context)
     {
-        var rootExpression = Parser.Parse(code);
+        var rootExpression = ParseRootExpression(code);
         return rootExpression switch
         {
             OpenRootExpression open => BuildOpenExpression(open.Expression, context),
@@ -32,6 +32,20 @@ public class ExpressionFactory : BaseExpressionFactory
             _ => throw new ParseException($"Unsupported expression root '{rootExpression.GetType().Name}'.")
         };
     }
+
+    public IFunction InstantiateClosed(string code, IContext context)
+    {
+        var rootExpression = ParseRootExpression(code);
+        return rootExpression switch
+        {
+            ClosedRootExpression closed => BuildClosedExpression(closed.Expression, context),
+            OpenRootExpression open => throw new ExpressionRequiresInputException(open.Expression.Members.FirstOrDefault()?.Name),
+            _ => throw new ParseException($"Unsupported expression root '{rootExpression.GetType().Name}'.")
+        };
+    }
+
+    private IRootExpression ParseRootExpression(string code)
+        => Parser.Parse(code);
 
     public IFunction Instantiate(string name, IParameter[] parameters, IContext context)
         => Instantiate<IFunction>(name, parameters, context);

--- a/Expressif/Functions/Text/CasingFunctions.cs
+++ b/Expressif/Functions/Text/CasingFunctions.cs
@@ -73,7 +73,7 @@ public class SwapCase : BaseTextCasing
 }
 
 /// <summary>
-/// Returns the input text in sentence case by capitalizing the first word while preserving the remaining content. Words containing dots, ampersands, or uppercase letters beyond the first character are treated as already correctly cased and preserved as-is (for example `example.com`, `AT&T`, and `iTunes`). Returns `null` when the input is `null`, `DBNull`, `(null)`, or a zero-length array.
+/// Returns the input text in sentence case by capitalizing the first word while preserving the remaining content. Words containing dots, ampersands, or uppercase letters beyond the first character are treated as already correctly cased and preserved as-is (for example `example.com`, `AT&amp;T`, and `iTunes`). Returns `null` when the input is `null`, `DBNull`, `(null)`, or a zero-length array.
 /// </summary>
 [Function(prefix: "", aliases: ["text-to-sentence-case", "capitalize"])]
 public class SentenceCase : BaseTextCasing
@@ -104,7 +104,7 @@ public class SentenceCase : BaseTextCasing
 }
 
 /// <summary>
-/// Returns the input text in title case, capitalizing words while keeping small words lowercase only when they are neither first nor last and do not follow a colon. The first and last words are always capitalized, and a small word after a colon is capitalized. Words containing dots, ampersands, or uppercase letters beyond the first character are treated as already correctly cased and preserved as-is (for example `example.com`, `Q&A`, and `iTunes`). Returns `null` when the input is `null`, `DBNull`, `(null)`, or a zero-length array.
+/// Returns the input text in title case, capitalizing words while keeping small words lowercase only when they are neither first nor last and do not follow a colon. The first and last words are always capitalized, and a small word after a colon is capitalized. Words containing dots, ampersands, or uppercase letters beyond the first character are treated as already correctly cased and preserved as-is (for example `example.com`, `Q&amp;A`, and `iTunes`). Returns `null` when the input is `null`, `DBNull`, `(null)`, or a zero-length array.
 /// </summary>
 [Function(prefix: "", aliases: ["text-to-title-case"])]
 public class TitleCase : BaseTextCasing

--- a/Expressif/Parsers/Expression.cs
+++ b/Expressif/Parsers/Expression.cs
@@ -49,11 +49,8 @@ public class ClosedExpression : IExpression
     public Function? GetImplicitFoldAccumulator()
         => IsImplicitFoldAggregation ? Members.First() : null;
 
-    private static readonly Parser<IParameter> NonLiteralRootParameterParser =
-        Parsers.Parameter.Parser.Where(x => x is not LiteralParameter);
-
-    private static readonly Parser<ClosedExpression> NonLiteralRootParser =
-        from parameter in NonLiteralRootParameterParser.Token()
+    private static readonly Parser<ClosedExpression> AnyRootParser =
+        from parameter in Parsers.Parameter.Parser.Token()
         from remaining in (
             from _ in Parse.Char('|').Token()
             from expression in OpenExpression.Parser
@@ -61,12 +58,8 @@ public class ClosedExpression : IExpression
         ).Optional()
         select new ClosedExpression(parameter, remaining.GetOrElse(Enumerable.Empty<Function>()));
 
-    private static readonly Parser<ClosedExpression> LiteralRootOnlyParser =
-        from parameter in Parsers.Parameter.Parser.Where(x => x is LiteralParameter).Token()
-        select new ClosedExpression(parameter, Enumerable.Empty<Function>());
-
     public static readonly Parser<ClosedExpression> Parser =
-        NonLiteralRootParser.Or(LiteralRootOnlyParser);
+        AnyRootParser;
 }
 
 [Obsolete("Use OpenExpression instead.")]

--- a/docs/_docs/using-expressif-cli.md
+++ b/docs/_docs/using-expressif-cli.md
@@ -38,7 +38,32 @@ expressif version --help
 
 ## Evaluating an expression
 
-The evaluate command requires an input value. Use --input, or its short form -i, to provide the value passed to the expression.
+Use `evaluate` to execute an expression. The expression can be supplied inline or loaded from a file.
+
+### Supplying the expression
+
+Provide the expression inline as a positional argument:
+
+```console
+expressif evaluate "absolute | add(5)"
+```
+
+Or load it from a UTF-8 file with `--file` (alias: `-f`):
+
+```console
+expressif evaluate --file ./expressions/transform.expr
+```
+
+The expression must be provided through exactly one source:
+
+- inline argument; or
+- `--file` / `-f`.
+
+Providing both sources, or neither source, returns an error.
+
+### Input-based evaluation
+
+Use `--input` (alias: `-i`) when the expression should be evaluated against an explicit input value.
 
 ```console
 expressif evaluate "absolute | add(5)" --input -12
@@ -56,6 +81,42 @@ The short form is equivalent:
 expressif evaluate "absolute | add(5)" -i -12
 ```
 
+### ClosedExpression evaluation (no input)
+
+When `--input` is not provided, the expression is evaluated as a `ClosedExpression` and executed exactly once.
+
+```console
+expressif evaluate "5 | add(3)"
+```
+
+```text
+8
+```
+
+This path is intended for expressions fully defined by literals, variables, context parameters, and functions.
+
+If the expression requires an input (for example an open expression like `upper`), evaluation fails with an explicit message instructing you to use `--input`.
+
+### Evaluating from a file
+
+Expression files are read as UTF-8 and may contain multiline expressions.
+
+```text
+5
+| add(3)
+| multiply(2)
+```
+
+```console
+expressif evaluate --file calculation.expr
+```
+
+```text
+16
+```
+
+Relative paths are resolved from the current working directory. Absolute paths are also supported.
+
 ### Null results
 
 When an expression returns no value, the CLI writes:
@@ -68,12 +129,64 @@ null
 
 If the expression is valid but fails during evaluation, the error message is written to standard error and the command returns exit code `3`.
 
+### Expression file errors
+
+Expression-file loading returns clear diagnostics when:
+
+- the file does not exist;
+- the path points to a directory;
+- the file cannot be accessed;
+- the file is empty or whitespace only;
+- the file content is not valid UTF-8;
+- the loaded expression is invalid.
+
 ## Validating an expression
 
 Use `validate` to check whether an expression can be parsed and constructed without evaluating it.
 
+As with `evaluate`, the expression can be provided inline or loaded from a file.
+
+By default, `validate` checks the expression as an open expression.
+
+You can provide `--open` explicitly, but this is the default behavior.
+
+Use `--closed` to validate the expression strictly as a closed expression.
+
+`--open` and `--closed` are mutually exclusive.
+
 ```text
 expressif validate <expression>
+```
+
+You can also load a UTF-8 expression file:
+
+```console
+expressif validate --file ./expressions/transform.expr
+```
+
+The short form is equivalent:
+
+```console
+expressif validate -f ./expressions/transform.expr
+```
+
+For `validate`, the expression must be supplied through exactly one source:
+
+- inline argument; or
+- `--file` / `-f`.
+
+Examples:
+
+```console
+expressif validate "upper"
+```
+
+```console
+expressif validate "upper" --open
+```
+
+```console
+expressif validate "5 | add(3)" --closed
 ```
 
 For example:


### PR DESCRIPTION
* **New Features**
  * Added file-based expression input for `evaluate` and `validate` using `--file`/`-f`.
  * Added explicit open and closed evaluation/validation modes.
  * Added support for UTF-8, BOM-free, and multiline expression files.
  * Improved handling of expressions that require input, including actionable guidance.

* **Bug Fixes**
  * Improved diagnostics for missing, empty, invalid, inaccessible, or conflicting expression inputs.
  * Enhanced source-aware validation and runtime error messages.

* **Documentation**
  * Expanded CLI documentation with file input, modes, path handling, and diagnostic examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->