### PR TITLE
feat(cli): support row-oriented sources in expressif run

### DIFF
--- a/Expressif.Cli.Tests/CliCommandTests.cs
+++ b/Expressif.Cli.Tests/CliCommandTests.cs
@@ -662,6 +662,29 @@ public class CliCommandTests
     }
 
     [Test]
+    public async Task Run_SourceCsvPathWithGenericDataReader_DoesNotSkipFirstRow()
+    {
+        RunCommand.ResolveSourceValue = static _ =>
+        {
+            var dataTable = new DataTable();
+            dataTable.Columns.Add("name", typeof(string));
+            dataTable.Rows.Add("Alice");
+            dataTable.Rows.Add("Bob");
+            return dataTable.CreateDataReader();
+        };
+
+        var result = await InvokeAsync("run", "[name] | upper", "--source", "customers.csv");
+
+        var outputs = result.StdOut.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.Success));
+            Assert.That(outputs, Is.EqualTo(new[] { "ALICE", "BOB" }));
+            Assert.That(result.StdErr, Is.Empty);
+        });
+    }
+
+    [Test]
     public async Task Run_SourceAndInputOptionsTogether_ReturnsClearError()
     {
         var sourcePath = CreateTempFile("{1,2,3}");

--- a/Expressif.Cli.Tests/CliCommandTests.cs
+++ b/Expressif.Cli.Tests/CliCommandTests.cs
@@ -1,4 +1,5 @@
 using Expressif.Cli.Commands;
+using System.Data;
 
 namespace Expressif.Cli.Tests;
 
@@ -514,6 +515,168 @@ public class CliCommandTests
     }
 
     [Test]
+    public async Task Run_SourceEnumerableExpression_EvaluatesEachRow()
+    {
+        var sourcePath = CreateTempFile("{1, -2, 3}");
+
+        var result = await InvokeAsync("run", "absolute", "--source", sourcePath);
+
+        var outputs = result.StdOut.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.Success));
+            Assert.That(outputs, Is.EqualTo(new[] { "1", "2", "3" }));
+            Assert.That(result.StdErr, Is.Empty);
+        });
+    }
+
+    [Test]
+    public async Task Run_SourceCsv_EvaluatesEachRecord()
+    {
+        var sourcePath = CreateTempFile($"name,age,country{Environment.NewLine}Alice,32,Belgium{Environment.NewLine}Bob,41,France{Environment.NewLine}Charlie,27,Germany", ".csv");
+
+        var result = await InvokeAsync("run", "[name] | upper", "--source", sourcePath);
+
+        var outputs = result.StdOut.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.Success));
+            Assert.That(outputs, Is.EqualTo(new[] { "ALICE", "BOB", "CHARLIE" }));
+            Assert.That(result.StdErr, Is.Empty);
+        });
+    }
+
+    [Test]
+    public async Task Run_SourceCsvHeaderOnly_ProducesNoOutputAndSuccess()
+    {
+        var sourcePath = CreateTempFile("name,age,country", ".csv");
+
+        var result = await InvokeAsync("run", "[name] | upper", "--source", sourcePath);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.Success));
+            Assert.That(result.StdOut, Is.Empty);
+            Assert.That(result.StdErr, Is.Empty);
+        });
+    }
+
+    [Test]
+    public async Task Run_SourceCsvEmpty_ReturnsClearError()
+    {
+        var sourcePath = CreateTempFile(string.Empty, ".csv");
+
+        var result = await InvokeAsync("run", "[name] | upper", "--source", sourcePath);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.InvalidExpressionOrInput));
+            Assert.That(result.StdOut, Is.Empty);
+            Assert.That(result.StdErr, Does.Contain("is empty. A header row is required."));
+        });
+    }
+
+    [Test]
+    public async Task Run_SourceCsvDuplicateHeaders_ReturnsClearError()
+    {
+        var sourcePath = CreateTempFile($"name,name,country{Environment.NewLine}Alice,32,Belgium", ".csv");
+
+        var result = await InvokeAsync("run", "[name] | upper", "--source", sourcePath);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.InvalidExpressionOrInput));
+            Assert.That(result.StdOut, Is.Empty);
+            Assert.That(result.StdErr, Does.Contain("contains duplicate column name 'name'"));
+        });
+    }
+
+    [Test]
+    public async Task Run_SourceCsvInconsistentFields_ReturnsClearError()
+    {
+        var sourcePath = CreateTempFile($"name,age,country{Environment.NewLine}Alice,32,Belgium{Environment.NewLine}Bob,41", ".csv");
+
+        var result = await InvokeAsync("run", "[name] | upper", "--source", sourcePath);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.InvalidExpressionOrInput));
+            Assert.That(result.StdOut.Trim(), Is.EqualTo("ALICE"));
+            Assert.That(result.StdErr, Does.Contain("contains 2 fields, but 3 fields were expected"));
+        });
+    }
+
+    [Test]
+    public async Task Run_SourceScalar_ReturnsClearError()
+    {
+        var sourcePath = CreateTempFile("42");
+
+        var result = await InvokeAsync("run", "add(1)", "--source", sourcePath);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.InvalidExpressionOrInput));
+            Assert.That(result.StdOut, Is.Empty);
+            Assert.That(result.StdErr, Does.Contain("returned a scalar value"));
+            Assert.That(result.StdErr, Does.Contain("Expected an IEnumerable or IDataReader"));
+        });
+    }
+
+    [Test]
+    public async Task Run_SourceNull_ReturnsClearError()
+    {
+        RunCommand.ResolveSourceValue = static _ => null;
+
+        var result = await InvokeAsync("run", "add(1)", "--source", "source.expr");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.InvalidExpressionOrInput));
+            Assert.That(result.StdOut, Is.Empty);
+            Assert.That(result.StdErr, Does.Contain("returned null"));
+            Assert.That(result.StdErr, Does.Contain("Expected an IEnumerable or IDataReader"));
+        });
+    }
+
+    [Test]
+    public async Task Run_SourceDataReader_EvaluatesEachRecord()
+    {
+        RunCommand.ResolveSourceValue = static _ =>
+        {
+            var dataTable = new DataTable();
+            dataTable.Columns.Add("name", typeof(string));
+            dataTable.Rows.Add("Alice");
+            dataTable.Rows.Add("Bob");
+            return dataTable.CreateDataReader();
+        };
+
+        var result = await InvokeAsync("run", "#0 | upper", "--source", "customers.sql");
+
+        var outputs = result.StdOut.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.Success));
+            Assert.That(outputs, Is.EqualTo(new[] { "ALICE", "BOB" }));
+            Assert.That(result.StdErr, Is.Empty);
+        });
+    }
+
+    [Test]
+    public async Task Run_SourceAndInputOptionsTogether_ReturnsClearError()
+    {
+        var sourcePath = CreateTempFile("{1,2,3}");
+
+        var result = await InvokeAsync("run", "add(1)", "--source", sourcePath, "--input", "1");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.InvalidExpressionOrInput));
+            Assert.That(result.StdOut, Is.Empty);
+            Assert.That(result.StdErr.Trim(), Is.EqualTo("The --source option cannot be combined with --input or --batch."));
+        });
+    }
+
+    [Test]
     public async Task Run_MissingInputOption_ReturnsClearError()
     {
         var result = await InvokeAsync("run", "absolute");
@@ -522,7 +685,7 @@ public class CliCommandTests
         {
             Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.InvalidExpressionOrInput));
             Assert.That(result.StdOut, Is.Empty);
-            Assert.That(result.StdErr.Trim(), Is.EqualTo("The run command requires inputs. Provide at least one --input row or one --batch enumerable value."));
+            Assert.That(result.StdErr.Trim(), Is.EqualTo("The run command requires inputs. Provide --input, --batch, or --source."));
         });
     }
 
@@ -848,9 +1011,9 @@ public class CliCommandTests
         }
     }
 
-    private string CreateTempFile(string content)
+    private string CreateTempFile(string content, string extension = ".expr")
     {
-        var path = Path.Combine(Path.GetTempPath(), $"expressif-{Guid.NewGuid():N}.expr");
+        var path = Path.Combine(Path.GetTempPath(), $"expressif-{Guid.NewGuid():N}{extension}");
         File.WriteAllText(path, content, new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
         tempFilesToDelete.Add(path);
         return path;

--- a/Expressif.Cli/Commands/RunCommand.cs
+++ b/Expressif.Cli/Commands/RunCommand.cs
@@ -316,9 +316,9 @@ internal static class RunCommand
 
     private static IEnumerable<object?> EnumerateReaderRows(IDataReader reader, string sourcePath)
     {
-        var isCsvSource = Path.GetExtension(sourcePath).Equals(".csv", StringComparison.OrdinalIgnoreCase);
+        var hasHeaderRecord = reader is DisposableDataReader wrappedReader && wrappedReader.HasHeaderRecord;
 
-        if (isCsvSource)
+        if (hasHeaderRecord)
         {
             foreach (var row in EnumerateCsvRows(reader, sourcePath))
                 yield return row;
@@ -491,7 +491,7 @@ internal static class RunCommand
             stream = new FileStream(sourcePath, FileMode.Open, FileAccess.Read, FileShare.Read);
             var csvReader = new CsvReader(CsvProfile.CommaDoubleQuote);
             var csvDataReader = csvReader.ToDataReader(stream);
-            return new DisposableDataReader(csvDataReader, stream);
+            return new DisposableDataReader(csvDataReader, stream, hasHeaderRecord: true);
         }
         catch
         {
@@ -696,7 +696,9 @@ internal static class RunCommand
             => ordinals.ContainsKey(columnName);
 
         public object? this[string columnName]
-            => ordinals.TryGetValue(columnName, out var index) ? values[index] : throw new ArgumentOutOfRangeException(columnName);
+            => ordinals.TryGetValue(columnName, out var index)
+                ? values[index]
+                : throw new ArgumentOutOfRangeException(nameof(columnName), columnName, $"Column '{columnName}' does not exist.");
 
         public object? this[int index]
             => values[index];
@@ -707,11 +709,14 @@ internal static class RunCommand
         private readonly IDataReader inner;
         private readonly IDisposable owner;
 
-        public DisposableDataReader(IDataReader inner, IDisposable owner)
+        public DisposableDataReader(IDataReader inner, IDisposable owner, bool hasHeaderRecord = false)
         {
             this.inner = inner;
             this.owner = owner;
+            HasHeaderRecord = hasHeaderRecord;
         }
+
+        public bool HasHeaderRecord { get; }
 
         public int Depth => inner.Depth;
         public bool IsClosed => inner.IsClosed;
@@ -720,14 +725,30 @@ internal static class RunCommand
         public object this[int i] => inner[i];
         public object this[string name] => inner[name]!;
 
-        public void Close() => inner.Close();
+        public void Close()
+        {
+            try
+            {
+                inner.Close();
+            }
+            finally
+            {
+                owner.Dispose();
+            }
+        }
         public DataTable GetSchemaTable() => inner.GetSchemaTable()!;
         public bool NextResult() => inner.NextResult();
         public bool Read() => inner.Read();
         public void Dispose()
         {
-            inner.Dispose();
-            owner.Dispose();
+            try
+            {
+                inner.Dispose();
+            }
+            finally
+            {
+                owner.Dispose();
+            }
         }
 
         public bool GetBoolean(int i) => inner.GetBoolean(i);

--- a/Expressif.Cli/Commands/RunCommand.cs
+++ b/Expressif.Cli/Commands/RunCommand.cs
@@ -1,29 +1,47 @@
 using System.Collections;
 using System.CommandLine;
+using System.Data;
 using System.Globalization;
+using System.Reflection;
 using System.Text;
+using PocketCsvReader;
 
 namespace Expressif.Cli.Commands;
 
 internal static class RunCommand
 {
     private static readonly Func<string, Context, Expression> DefaultBuildExpression = static (code, context) => new Expression(code, context);
+    private static readonly Func<string, Context, ClosedExpression> DefaultBuildClosedExpression = static (code, context) => new ClosedExpression(code, context);
+    private static readonly Func<ClosedExpression, object?> DefaultEvaluateClosedExpression = static expression => expression.Evaluate();
     private static readonly Func<string, object?> DefaultParseInput = static input => InputValueParser.Parse(input);
-    private static readonly Func<Expression, IEnumerable, IEnumerable<object?>> DefaultRunExpression = static (expression, inputs) => EvaluateEach(expression, inputs);
+    private static readonly Func<string, object?> DefaultResolveSourceValue = ResolveSourceValueCore;
+    private static readonly Func<Expression, Context, IEnumerable, IEnumerable<object?>> DefaultRunExpression = static (expression, context, inputs) => EvaluateEach(expression, context, inputs);
 
     internal static Func<string, Context, Expression> BuildExpression { get; set; }
         = DefaultBuildExpression;
 
+    internal static Func<string, Context, ClosedExpression> BuildClosedExpression { get; set; }
+        = DefaultBuildClosedExpression;
+
+    internal static Func<ClosedExpression, object?> EvaluateClosedExpression { get; set; }
+        = DefaultEvaluateClosedExpression;
+
     internal static Func<string, object?> ParseInput { get; set; }
         = DefaultParseInput;
 
-    internal static Func<Expression, IEnumerable, IEnumerable<object?>> RunExpression { get; set; }
+    internal static Func<string, object?> ResolveSourceValue { get; set; }
+        = DefaultResolveSourceValue;
+
+    internal static Func<Expression, Context, IEnumerable, IEnumerable<object?>> RunExpression { get; set; }
         = DefaultRunExpression;
 
     internal static void ResetDelegates()
     {
         BuildExpression = DefaultBuildExpression;
+        BuildClosedExpression = DefaultBuildClosedExpression;
+        EvaluateClosedExpression = DefaultEvaluateClosedExpression;
         ParseInput = DefaultParseInput;
+        ResolveSourceValue = DefaultResolveSourceValue;
         RunExpression = DefaultRunExpression;
     }
 
@@ -52,21 +70,30 @@ internal static class RunCommand
         };
         expressionFileOption.Aliases.Add("-f");
 
+        var sourceOption = new Option<string?>("--source")
+        {
+            Description = "Path to a source file returning rows as IEnumerable or IDataReader."
+        };
+        sourceOption.Aliases.Add("-s");
+
         var command = new Command("run", "Evaluate an Expressif expression for each element of an input sequence.");
 
         command.Arguments.Add(expressionArgument);
         command.Options.Add(inputOption);
         command.Options.Add(batchOption);
+        command.Options.Add(sourceOption);
         command.Options.Add(expressionFileOption);
 
         command.SetAction(parseResult =>
         {
             var inlineExpression = parseResult.GetValue(expressionArgument);
             var expressionFilePath = parseResult.GetValue(expressionFileOption);
+            var sourcePath = parseResult.GetValue(sourceOption);
             var inputRows = parseResult.GetValue(inputOption) ?? [];
             var batchInput = parseResult.GetValue(batchOption);
             var hasInputOption = parseResult.GetResult(inputOption) is not null;
             var hasBatchOption = parseResult.GetResult(batchOption) is not null;
+            var hasSourceOption = parseResult.GetResult(sourceOption) is not null;
 
             var batchOptionOccurrences = parseResult.Tokens.Count(token => token.Value is "--batch");
             if (batchOptionOccurrences > 1)
@@ -84,18 +111,27 @@ internal static class RunCommand
                 return ExitCodes.InvalidExpressionOrInput;
             }
 
-            if (!hasInputOption && !hasBatchOption)
+            if (!hasInputOption && !hasBatchOption && !hasSourceOption)
             {
-                Console.Error.WriteLine("The run command requires inputs. Provide at least one --input row or one --batch enumerable value.");
+                Console.Error.WriteLine("The run command requires inputs. Provide --input, --batch, or --source.");
                 return ExitCodes.InvalidExpressionOrInput;
             }
 
-            var sequenceInput = BuildInputSequence(inputRows, hasBatchOption, batchInput);
+            if (hasSourceOption && (hasInputOption || hasBatchOption))
+            {
+                Console.Error.WriteLine("The --source option cannot be combined with --input or --batch.");
+                return ExitCodes.InvalidExpressionOrInput;
+            }
 
+            var sequenceInput = hasSourceOption
+                ? BuildSourceRows(sourcePath)
+                : BuildInputSequence(inputRows, hasBatchOption, batchInput);
+
+            var context = new Context();
             Expression openExpression;
             try
             {
-                openExpression = BuildExpression(expressionCode, new Context());
+                openExpression = BuildExpression(expressionCode, context);
             }
             catch (Exception exception) when (exception is Sprache.ParseException
                                               or NotImplementedFunctionException
@@ -111,7 +147,7 @@ internal static class RunCommand
 
             try
             {
-                foreach (var result in RunExpression(openExpression, sequenceInput))
+                foreach (var result in RunExpression(openExpression, context, sequenceInput))
                     Console.Out.WriteLine(result ?? "null");
 
                 return ExitCodes.Success;
@@ -131,7 +167,7 @@ internal static class RunCommand
         return command;
     }
 
-    private static IEnumerable<object?> EvaluateEach(Expression expression, IEnumerable inputs)
+    private static IEnumerable<object?> EvaluateEach(Expression expression, Context context, IEnumerable inputs)
     {
         var enumerator = inputs.GetEnumerator();
         var index = 0;
@@ -157,13 +193,18 @@ internal static class RunCommand
                 object? result;
                 try
                 {
+                    context.CurrentObject.Set(input);
                     result = expression.Evaluate(input);
                 }
                 catch (Exception exception) when (exception is not OutOfMemoryException)
                 {
+                    var rootCause = exception is TargetInvocationException invocationException
+                        ? invocationException.InnerException ?? exception
+                        : exception;
+
                     throw new InvalidOperationException(
-                        $"Expression evaluation failed for input {FormatValue(input)}: {exception.Message}",
-                        exception);
+                        $"Expression evaluation failed for input {FormatValue(input)}: {rootCause.Message}",
+                        rootCause);
                 }
 
                 yield return result;
@@ -224,6 +265,262 @@ internal static class RunCommand
         finally
         {
             (enumerator as IDisposable)?.Dispose();
+        }
+    }
+
+    private static IEnumerable<object?> BuildSourceRows(string? sourcePath)
+    {
+        object? sourceValue;
+        try
+        {
+            sourceValue = ResolveSourceValue(sourcePath ?? string.Empty);
+        }
+        catch (FormatException)
+        {
+            throw;
+        }
+        catch (Exception exception) when (exception is not OutOfMemoryException)
+        {
+            throw new FormatException($"The source '{sourcePath}' could not be resolved: {exception.Message}", exception);
+        }
+
+        if (sourceValue is null)
+            throw new FormatException("The source supplied to 'run' returned null. Expected an IEnumerable or IDataReader.");
+
+        if (sourceValue is IDataReader reader)
+        {
+            foreach (var row in EnumerateReaderRows(reader, sourcePath ?? string.Empty))
+                yield return row;
+
+            yield break;
+        }
+
+        if (sourceValue is IEnumerable enumerable and not string)
+        {
+            var enumerator = enumerable.GetEnumerator();
+            try
+            {
+                while (enumerator.MoveNext())
+                    yield return enumerator.Current;
+            }
+            finally
+            {
+                (enumerator as IDisposable)?.Dispose();
+            }
+
+            yield break;
+        }
+
+        throw new FormatException("The source supplied to 'run' returned a scalar value. Expected an IEnumerable or IDataReader.");
+    }
+
+    private static IEnumerable<object?> EnumerateReaderRows(IDataReader reader, string sourcePath)
+    {
+        var isCsvSource = Path.GetExtension(sourcePath).Equals(".csv", StringComparison.OrdinalIgnoreCase);
+
+        if (isCsvSource)
+        {
+            foreach (var row in EnumerateCsvRows(reader, sourcePath))
+                yield return row;
+
+            yield break;
+        }
+
+        foreach (var row in EnumerateGenericReaderRows(reader, sourcePath))
+            yield return row;
+    }
+
+    private static IEnumerable<object?> EnumerateGenericReaderRows(IDataReader reader, string sourcePath)
+    {
+        try
+        {
+            while (true)
+            {
+                bool hasRow;
+                try
+                {
+                    hasRow = reader.Read();
+                }
+                catch (Exception exception) when (exception is not OutOfMemoryException)
+                {
+                    throw new FormatException($"Reading from source '{sourcePath}' failed: {exception.Message}", exception);
+                }
+
+                if (!hasRow)
+                    yield break;
+
+                yield return BuildLiteDataRow(reader);
+            }
+        }
+        finally
+        {
+            reader.Dispose();
+        }
+    }
+
+    private static IEnumerable<object?> EnumerateCsvRows(IDataReader reader, string sourcePath)
+    {
+        try
+        {
+            bool hasHeader;
+            try
+            {
+                hasHeader = reader.Read();
+            }
+            catch (Exception exception) when (exception is not OutOfMemoryException)
+            {
+                throw new FormatException($"Invalid CSV syntax in '{sourcePath}': {exception.Message}", exception);
+            }
+
+            if (!hasHeader)
+                throw new FormatException($"CSV source '{sourcePath}' is empty. A header row is required.");
+
+            var expectedFields = reader.FieldCount;
+            if (expectedFields == 0)
+                throw new FormatException($"CSV source '{sourcePath}' is empty. A header row is required.");
+
+            var headers = new string[expectedFields];
+            var headerSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            for (var i = 0; i < expectedFields; i++)
+            {
+                var header = Convert.ToString(reader.GetValue(i), CultureInfo.InvariantCulture) ?? string.Empty;
+                if (string.IsNullOrEmpty(header))
+                    throw new FormatException($"CSV header in '{sourcePath}' is invalid: field {i + 1} is empty.");
+
+                if (!headerSet.Add(header))
+                    throw new FormatException($"CSV header in '{sourcePath}' contains duplicate column name '{header}'.");
+
+                headers[i] = header;
+            }
+
+            var recordNumber = 2;
+            while (true)
+            {
+                bool hasRow;
+                try
+                {
+                    hasRow = reader.Read();
+                }
+                catch (Exception exception) when (exception is not OutOfMemoryException)
+                {
+                    throw new FormatException($"Invalid CSV syntax in '{sourcePath}': {exception.Message}", exception);
+                }
+
+                if (!hasRow)
+                    yield break;
+
+                var actualFields = reader.FieldCount;
+                if (actualFields != expectedFields)
+                    throw new FormatException($"CSV record {recordNumber} in '{sourcePath}' contains {actualFields} fields, but {expectedFields} fields were expected.");
+
+                var values = new object?[expectedFields];
+                for (var i = 0; i < expectedFields; i++)
+                {
+                    var value = reader.GetValue(i);
+                    values[i] = value is DBNull ? null : value;
+                }
+
+                yield return new LiteDataRow(headers, values);
+                recordNumber++;
+            }
+        }
+        finally
+        {
+            reader.Dispose();
+        }
+    }
+
+    private static LiteDataRow BuildLiteDataRow(IDataReader reader)
+    {
+        var fields = reader.FieldCount;
+        var names = new string[fields];
+        var values = new object?[fields];
+        for (var i = 0; i < fields; i++)
+        {
+            names[i] = reader.GetName(i);
+            var value = reader.GetValue(i);
+            values[i] = value is DBNull ? null : value;
+        }
+
+        return new LiteDataRow(names, values);
+    }
+
+    private static object? ResolveSourceValueCore(string sourcePath)
+    {
+        if (string.IsNullOrWhiteSpace(sourcePath))
+            throw new FormatException("Source path is required.");
+
+        if (Directory.Exists(sourcePath))
+            throw new FormatException($"Source '{sourcePath}' is a directory.");
+
+        if (!File.Exists(sourcePath))
+            throw new FormatException($"Source '{sourcePath}' was not found.");
+
+        if (Path.GetExtension(sourcePath).Equals(".csv", StringComparison.OrdinalIgnoreCase))
+            return OpenCsvDataReader(sourcePath);
+
+        var sourceCode = ReadUtf8File(sourcePath);
+        ClosedExpression closedExpression;
+        try
+        {
+            closedExpression = BuildClosedExpression(sourceCode, new Context());
+        }
+        catch (Exception exception) when (exception is Sprache.ParseException
+                                          or NotImplementedFunctionException
+                                          or MissingOrUnexpectedParametersFunctionException
+                                          or ExpressionRequiresInputException)
+        {
+            throw new FormatException($"The source '{sourcePath}' is invalid: {CommandErrorFormatter.FormatValidationError(exception)}", exception);
+        }
+
+        try
+        {
+            return EvaluateClosedExpression(closedExpression);
+        }
+        catch (Exception exception) when (exception is not OutOfMemoryException)
+        {
+            throw new FormatException($"The source '{sourcePath}' could not be evaluated: {exception.Message}", exception);
+        }
+    }
+
+    private static IDataReader OpenCsvDataReader(string sourcePath)
+    {
+        FileStream? stream = null;
+        try
+        {
+            stream = new FileStream(sourcePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+            var csvReader = new CsvReader(CsvProfile.CommaDoubleQuote);
+            var csvDataReader = csvReader.ToDataReader(stream);
+            return new DisposableDataReader(csvDataReader, stream);
+        }
+        catch
+        {
+            stream?.Dispose();
+            throw;
+        }
+    }
+
+    private static string ReadUtf8File(string sourcePath)
+    {
+        try
+        {
+            using var stream = new FileStream(sourcePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+            using var reader = new StreamReader(
+                stream,
+                new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true),
+                detectEncodingFromByteOrderMarks: true);
+            return reader.ReadToEnd();
+        }
+        catch (DecoderFallbackException exception)
+        {
+            throw new FormatException($"Source '{sourcePath}' could not be decoded as UTF-8.", exception);
+        }
+        catch (Exception exception) when (exception is IOException
+                                          or UnauthorizedAccessException
+                                          or ArgumentException
+                                          or NotSupportedException)
+        {
+            throw new FormatException($"Source '{sourcePath}' could not be accessed: {exception.Message}", exception);
         }
     }
 
@@ -375,5 +672,87 @@ internal static class RunCommand
                 return token;
             }
         }
+    }
+
+    private sealed class LiteDataRow : Expressif.Values.ILiteDataRow
+    {
+        private readonly string[] names;
+        private readonly object?[] values;
+        private readonly Dictionary<string, int> ordinals;
+
+        public LiteDataRow(string[] names, object?[] values)
+        {
+            this.names = names;
+            this.values = values;
+            ordinals = new Dictionary<string, int>(names.Length, StringComparer.OrdinalIgnoreCase);
+            for (var i = 0; i < names.Length; i++)
+                if (!ordinals.ContainsKey(names[i]))
+                    ordinals[names[i]] = i;
+        }
+
+        public int ColumnCount => values.Length;
+
+        public bool ContainsColumn(string columnName)
+            => ordinals.ContainsKey(columnName);
+
+        public object? this[string columnName]
+            => ordinals.TryGetValue(columnName, out var index) ? values[index] : throw new ArgumentOutOfRangeException(columnName);
+
+        public object? this[int index]
+            => values[index];
+    }
+
+    private sealed class DisposableDataReader : IDataReader
+    {
+        private readonly IDataReader inner;
+        private readonly IDisposable owner;
+
+        public DisposableDataReader(IDataReader inner, IDisposable owner)
+        {
+            this.inner = inner;
+            this.owner = owner;
+        }
+
+        public int Depth => inner.Depth;
+        public bool IsClosed => inner.IsClosed;
+        public int RecordsAffected => inner.RecordsAffected;
+        public int FieldCount => inner.FieldCount;
+        public object this[int i] => inner[i];
+        public object this[string name] => inner[name]!;
+
+        public void Close() => inner.Close();
+        public DataTable GetSchemaTable() => inner.GetSchemaTable()!;
+        public bool NextResult() => inner.NextResult();
+        public bool Read() => inner.Read();
+        public void Dispose()
+        {
+            inner.Dispose();
+            owner.Dispose();
+        }
+
+        public bool GetBoolean(int i) => inner.GetBoolean(i);
+        public byte GetByte(int i) => inner.GetByte(i);
+        public long GetBytes(int i, long fieldOffset, byte[]? buffer, int bufferoffset, int length)
+            => inner.GetBytes(i, fieldOffset, buffer, bufferoffset, length);
+        public char GetChar(int i) => inner.GetChar(i);
+        public long GetChars(int i, long fieldoffset, char[]? buffer, int bufferoffset, int length)
+            => inner.GetChars(i, fieldoffset, buffer, bufferoffset, length);
+        public IDataReader GetData(int i) => inner.GetData(i);
+        public string GetDataTypeName(int i) => inner.GetDataTypeName(i);
+        public DateTime GetDateTime(int i) => inner.GetDateTime(i);
+        public decimal GetDecimal(int i) => inner.GetDecimal(i);
+        public double GetDouble(int i) => inner.GetDouble(i);
+        public Type GetFieldType(int i) => inner.GetFieldType(i);
+        public float GetFloat(int i) => inner.GetFloat(i);
+        public Guid GetGuid(int i) => inner.GetGuid(i);
+        public short GetInt16(int i) => inner.GetInt16(i);
+        public int GetInt32(int i) => inner.GetInt32(i);
+        public long GetInt64(int i) => inner.GetInt64(i);
+        public string GetName(int i) => inner.GetName(i);
+        public int GetOrdinal(string name) => inner.GetOrdinal(name);
+        public string GetString(int i) => inner.GetString(i);
+        public object GetValue(int i) => inner.GetValue(i);
+        public int GetValues(object[] values) => inner.GetValues(values);
+        public bool IsDBNull(int i) => inner.IsDBNull(i);
     }
 }

--- a/Expressif.Cli/Expressif.Cli.csproj
+++ b/Expressif.Cli/Expressif.Cli.csproj
@@ -13,6 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="PocketCsvReader" Version="2.36.34" />
     <PackageReference Include="System.CommandLine" Version="2.*" />
   </ItemGroup>
 

--- a/Expressif.Syntax/New-PackageJson.ps1
+++ b/Expressif.Syntax/New-PackageJson.ps1
@@ -8,8 +8,7 @@ param(
 
 $model = [ordered]@{
         version = $Version
-    }
-    | ConvertTo-Json -Depth 20
+    } | ConvertTo-Json -Depth 20
 
 Write-Host "Model sets version to value '$Version'."
 

--- a/Expressif.Syntax/New-tmLanguage.ps1
+++ b/Expressif.Syntax/New-tmLanguage.ps1
@@ -27,8 +27,7 @@ $model = [ordered]@{
                     regex = [regex]::Escape($_.Name)
                 }
             }
-    }
-    | ConvertTo-Json -Depth 20
+    } | ConvertTo-Json -Depth 20
 
 Write-Host "Running Didot via local installation..."
 $model | dotnet tool run didot `
@@ -36,7 +35,7 @@ $model | dotnet tool run didot `
     -e scriban `
     -i `
     -r json `
-    -o $OutputPath `
+    -o $OutputPath
 
 if ($LASTEXITCODE -ne 0) {
     throw "Didot execution failed"

--- a/docs/_docs/using-expressif-cli.md
+++ b/docs/_docs/using-expressif-cli.md
@@ -103,6 +103,12 @@ Use `run` to evaluate an expression repeatedly over an input sequence.
 - `--input` (repeatable): each occurrence defines exactly one row, whether the value is scalar or enumerable;
 - `--batch` (single value): the value must be enumerable, and each direct element becomes one row.
 
+You can also use `--source` to read rows from a CSV file.
+
+- The first row is the header (column names).
+- Each following row is evaluated once.
+- Use column names in expressions, for example `[name]` or `[age]`.
+
 ```console
 expressif run "count" --input "{1, -2, 3}"
 ```
@@ -158,6 +164,31 @@ expressif run "count" --batch "{{1, 2, 3}, {4, 5}}"
 3
 2
 ```
+
+### Running from a CSV file
+
+Use `--source` to evaluate one row at a time from a CSV file:
+
+```console
+expressif run "[name] | upper" --source people.csv
+```
+
+How CSV input is handled:
+
+- the first row is treated as header;
+- each following row is an input record;
+- empty fields are represented as empty text;
+- duplicate header names are rejected;
+- malformed rows (wrong field count) fail with a clear error;
+- processing is streamed row by row so large files can be processed efficiently.
+
+Example:
+
+```console
+expressif run "[country] | upper" --source customers.csv
+```
+
+`--source` cannot be combined with `--input` or `--batch`.
 
 Expression loading works the same way as with `evaluate`: inline argument or `--file` (`-f`).
 

--- a/docs/_docs/using-expressif-cli.md
+++ b/docs/_docs/using-expressif-cli.md
@@ -98,16 +98,21 @@ The input is passed to the expression as text. The expression is responsible for
 
 Use `run` to evaluate an expression repeatedly over an input sequence.
 
-`run` accepts two complementary input options:
+`run` accepts three complementary input options:
 
 - `--input` (repeatable): each occurrence defines exactly one row, whether the value is scalar or enumerable;
-- `--batch` (single value): the value must be enumerable, and each direct element becomes one row.
+- `--batch` (single value): the value must be enumerable, and each direct element becomes one row;
+- `--source` (single file path): load rows from a source file.
 
-You can also use `--source` to read rows from a CSV file.
+How `--source` works:
 
-- The first row is the header (column names).
-- Each following row is evaluated once.
-- Use column names in expressions, for example `[name]` or `[age]`.
+- CSV files (`.csv`) use a header-and-rows pattern.
+- In CSV files, the first row is treated as the header (column names).
+- In CSV files, each following row is evaluated once.
+- In CSV files, use column names in expressions, for example `[name]` or `[age]`.
+- Non-CSV files (for example `.expr`) are evaluated as closed expressions.
+- A non-CSV source expression must return an enumerable.
+- Each direct element returned by a non-CSV source expression is evaluated once.
 
 ```console
 expressif run "count" --input "{1, -2, 3}"
@@ -165,15 +170,15 @@ expressif run "count" --batch "{{1, 2, 3}, {4, 5}}"
 2
 ```
 
-### Running from a CSV file
+### Running from a source file
 
-Use `--source` to evaluate one row at a time from a CSV file:
+Use `--source` to evaluate one row at a time from a source file.
 
 ```console
 expressif run "[name] | upper" --source people.csv
 ```
 
-How CSV input is handled:
+For CSV input:
 
 - the first row is treated as header;
 - each following row is an input record;
@@ -182,10 +187,16 @@ How CSV input is handled:
 - malformed rows (wrong field count) fail with a clear error;
 - processing is streamed row by row so large files can be processed efficiently.
 
-Example:
+For non-CSV source files, the source expression is evaluated first and must return an enumerable sequence.
+
+Examples:
 
 ```console
 expressif run "[country] | upper" --source customers.csv
+```
+
+```console
+expressif run "absolute | add(1)" --source values.expr
 ```
 
 `--source` cannot be combined with `--input` or `--batch`.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--source` support to the `run` command for CSV files, expression files, enumerable data, and data readers.
  * Added CSV row evaluation with headers, empty fields, streaming, and clear validation errors.
  * Improved error reporting for invalid sources, malformed files, and conflicting input options.

* **Documentation**
  * Added CLI guidance and examples for using CSV sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->