### PR TITLE
feat(cli): support scalar and array-shaped CSV sources in the CLI

### DIFF
--- a/Expressif.Cli.Tests/CliCommandTests.cs
+++ b/Expressif.Cli.Tests/CliCommandTests.cs
@@ -626,6 +626,57 @@ public class CliCommandTests
     }
 
     [Test]
+    public async Task Evaluate_SourceCsv_EvaluatesCompleteRecordArrayOnce()
+    {
+        var sourcePath = CreateTempFile($"name,age{Environment.NewLine}Alice,32{Environment.NewLine}Bob,41", ".csv");
+        var result = await InvokeAsync("evaluate", "count", "--source", sourcePath);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.Success));
+            Assert.That(result.StdOut.Trim(), Is.EqualTo("2"));
+            Assert.That(result.StdErr, Is.Empty);
+        });
+    }
+
+    [Test]
+    public async Task Evaluate_SourceCsvScalar_EvaluatesCompleteValueArrayOnce()
+    {
+        var sourcePath = CreateTempFile($"name{Environment.NewLine}Alice{Environment.NewLine}Bob", ".csv");
+        var result = await InvokeAsync("evaluate", "count", "--source", sourcePath, "--scalar");
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.Success));
+            Assert.That(result.StdOut.Trim(), Is.EqualTo("2"));
+            Assert.That(result.StdErr, Is.Empty);
+        });
+    }
+
+    [TestCase("name,age", false)]
+    [TestCase("name", true)]
+    public async Task Evaluate_SourceCsvHeaderOnly_EvaluatesEmptyArray(string header, bool scalar)
+    {
+        var sourcePath = CreateTempFile(header, ".csv");
+        var arguments = scalar
+            ? new[] { "evaluate", "count", "--source", sourcePath, "--scalar" }
+            : new[] { "evaluate", "count", "--source", sourcePath };
+        var result = await InvokeAsync(arguments);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.Success));
+            Assert.That(result.StdOut.Trim(), Is.EqualTo("0"));
+            Assert.That(result.StdErr, Is.Empty);
+        });
+    }
+
+    [Test]
+    public async Task Evaluate_SourceAndInputTogether_ReturnsClearError()
+    {
+        var sourcePath = CreateTempFile("name", ".csv");
+        var result = await InvokeAsync("evaluate", "count", "--source", sourcePath, "--input", "value");
+        Assert.That(result.StdErr.Trim(), Is.EqualTo("The --source option cannot be combined with --input."));
+    }
+
+    [Test]
     public async Task Run_SourceCsvScalar_EvaluatesEachValue()
     {
         var sourcePath = CreateTempFile($"name{Environment.NewLine}Alice{Environment.NewLine}Bob", ".csv");

--- a/Expressif.Cli.Tests/CliCommandTests.cs
+++ b/Expressif.Cli.Tests/CliCommandTests.cs
@@ -626,6 +626,47 @@ public class CliCommandTests
     }
 
     [Test]
+    public async Task Run_SourceCsvScalar_EvaluatesEachValue()
+    {
+        var sourcePath = CreateTempFile($"name{Environment.NewLine}Alice{Environment.NewLine}Bob", ".csv");
+        var result = await InvokeAsync("run", "upper", "--source", sourcePath, "--scalar");
+        var outputs = result.StdOut.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.Success));
+            Assert.That(outputs, Is.EqualTo(new[] { "ALICE", "BOB" }));
+            Assert.That(result.StdErr, Is.Empty);
+        });
+    }
+
+    [Test]
+    public async Task Run_SourceCsvScalarWithMultipleColumns_ReturnsClearError()
+    {
+        var sourcePath = CreateTempFile($"name,age{Environment.NewLine}Alice,32", ".csv");
+        var result = await InvokeAsync("run", "upper", "--source", sourcePath, "--scalar");
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.InvalidExpressionOrInput));
+            Assert.That(result.StdErr, Does.Contain("exactly one column; found 2"));
+        });
+    }
+
+    [Test]
+    public async Task Run_SourceCsvScalarHeaderOnly_IsValid()
+    {
+        var sourcePath = CreateTempFile("name", ".csv");
+        var result = await InvokeAsync("run", "upper", "--source", sourcePath, "--scalar");
+        Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.Success));
+    }
+
+    [Test]
+    public async Task Run_ScalarWithoutSource_ReturnsClearError()
+    {
+        var result = await InvokeAsync("run", "upper", "--input", "Alice", "--scalar");
+        Assert.That(result.StdErr.Trim(), Is.EqualTo("The --scalar option requires --source."));
+    }
+
+    [Test]
     public async Task Run_SourceCsv_EvaluatesEachRecord()
     {
         var sourcePath = CreateTempFile($"name,age,country{Environment.NewLine}Alice,32,Belgium{Environment.NewLine}Bob,41,France{Environment.NewLine}Charlie,27,Germany", ".csv");

--- a/Expressif.Cli/Commands/EvaluateCommand.cs
+++ b/Expressif.Cli/Commands/EvaluateCommand.cs
@@ -28,6 +28,17 @@ internal static class EvaluateCommand
         };
         inputOption.Aliases.Add("-i");
 
+        var sourceOption = new Option<string?>("--source")
+        {
+            Description = "Path to a CSV source whose complete row set is passed as one array."
+        };
+        sourceOption.Aliases.Add("-s");
+
+        var scalarOption = new Option<bool>("--scalar")
+        {
+            Description = "Treat each source row as a single value. The source must contain exactly one column."
+        };
+
         var expressionFileOption = new Option<string?>("--file")
         {
             Description = "Path to a UTF-8 file containing the expression to evaluate."
@@ -38,6 +49,8 @@ internal static class EvaluateCommand
 
         command.Arguments.Add(expressionArgument);
         command.Options.Add(inputOption);
+        command.Options.Add(sourceOption);
+        command.Options.Add(scalarOption);
         command.Options.Add(expressionFileOption);
 
         command.SetAction(parseResult =>
@@ -45,12 +58,27 @@ internal static class EvaluateCommand
             var inlineExpression = parseResult.GetValue(expressionArgument);
             var expressionFilePath = parseResult.GetValue(expressionFileOption);
             var input = parseResult.GetValue(inputOption);
+            var sourcePath = parseResult.GetValue(sourceOption);
+            var scalar = parseResult.GetValue(scalarOption);
             var hasInputOption = parseResult.GetResult(inputOption) is not null;
+            var hasSourceOption = parseResult.GetResult(sourceOption) is not null;
             var inputOptionOccurrences = parseResult.Tokens.Count(token => token.Value is "--input" or "-i");
 
             if (inputOptionOccurrences > 1)
             {
                 Console.Error.WriteLine("The --input option can only be specified once for evaluate.");
+                return ExitCodes.InvalidExpressionOrInput;
+            }
+
+            if (hasInputOption && hasSourceOption)
+            {
+                Console.Error.WriteLine("The --source option cannot be combined with --input.");
+                return ExitCodes.InvalidExpressionOrInput;
+            }
+
+            if (scalar && !hasSourceOption)
+            {
+                Console.Error.WriteLine("The --scalar option requires --source.");
                 return ExitCodes.InvalidExpressionOrInput;
             }
 
@@ -63,6 +91,9 @@ internal static class EvaluateCommand
                 return ExitCodes.InvalidExpressionOrInput;
             }
 
+            if (hasSourceOption)
+                return EvaluateSource(expressionCode, sourcePath, scalar, hasExpressionFile, expressionFilePath);
+
             if (!hasInputOption)
                 return EvaluateClosed(expressionCode, hasExpressionFile, expressionFilePath);
 
@@ -70,6 +101,22 @@ internal static class EvaluateCommand
         });
 
         return command;
+    }
+
+    private static int EvaluateSource(string expressionCode, string? sourcePath, bool scalar, bool hasExpressionFile, string? expressionFilePath)
+    {
+        object?[] sourceRows;
+        try
+        {
+            sourceRows = RunCommand.BuildSourceRows(sourcePath, scalar).ToArray();
+        }
+        catch (FormatException exception)
+        {
+            Console.Error.WriteLine(exception.Message);
+            return ExitCodes.InvalidExpressionOrInput;
+        }
+
+        return EvaluateOpen(expressionCode, sourceRows, hasExpressionFile, expressionFilePath);
     }
 
     private static int EvaluateClosed(string expressionCode, bool hasExpressionFile, string? expressionFilePath)
@@ -135,7 +182,7 @@ internal static class EvaluateCommand
         }
     }
 
-    private static int EvaluateOpen(string expressionCode, string? input, bool hasExpressionFile, string? expressionFilePath)
+    private static int EvaluateOpen(string expressionCode, object? input, bool hasExpressionFile, string? expressionFilePath)
     {
         Expressif.Expression openExpression;
             try

--- a/Expressif.Cli/Commands/RunCommand.cs
+++ b/Expressif.Cli/Commands/RunCommand.cs
@@ -80,12 +80,18 @@ internal static class RunCommand
         };
         sourceOption.Aliases.Add("-s");
 
+        var scalarOption = new Option<bool>("--scalar")
+        {
+            Description = "Treat each source row as a single value. The source must contain exactly one column."
+        };
+
         var command = new Command("run", "Evaluate an Expressif expression for each element of an input sequence.");
 
         command.Arguments.Add(expressionArgument);
         command.Options.Add(inputOption);
         command.Options.Add(batchOption);
         command.Options.Add(sourceOption);
+        command.Options.Add(scalarOption);
         command.Options.Add(expressionFileOption);
 
         command.SetAction(parseResult =>
@@ -93,11 +99,18 @@ internal static class RunCommand
             var inlineExpression = parseResult.GetValue(expressionArgument);
             var expressionFilePath = parseResult.GetValue(expressionFileOption);
             var sourcePath = parseResult.GetValue(sourceOption);
+            var scalar = parseResult.GetValue(scalarOption);
             var inputRows = parseResult.GetValue(inputOption) ?? [];
             var batchInput = parseResult.GetValue(batchOption);
             var hasInputOption = parseResult.GetResult(inputOption) is not null;
             var hasBatchOption = parseResult.GetResult(batchOption) is not null;
             var hasSourceOption = parseResult.GetResult(sourceOption) is not null;
+
+            if (scalar && !hasSourceOption)
+            {
+                Console.Error.WriteLine("The --scalar option requires --source.");
+                return ExitCodes.InvalidExpressionOrInput;
+            }
 
             var batchOptionOccurrences = parseResult.Tokens.Count(token => token.Value is "--batch");
             if (batchOptionOccurrences > 1)
@@ -128,7 +141,7 @@ internal static class RunCommand
             }
 
             var sequenceInput = hasSourceOption
-                ? BuildSourceRows(sourcePath)
+                ? BuildSourceRows(sourcePath, scalar)
                 : BuildInputSequence(inputRows, hasBatchOption, batchInput);
 
             var context = new Context();
@@ -272,7 +285,7 @@ internal static class RunCommand
         }
     }
 
-    private static IEnumerable<object?> BuildSourceRows(string? sourcePath)
+    internal static IEnumerable<object?> BuildSourceRows(string? sourcePath, bool scalar = false)
     {
         object? sourceValue;
         try
@@ -293,7 +306,7 @@ internal static class RunCommand
 
         if (sourceValue is IDataReader reader)
         {
-            foreach (var row in EnumerateReaderRows(reader, sourcePath ?? string.Empty))
+            foreach (var row in EnumerateReaderRows(reader, sourcePath ?? string.Empty, scalar))
                 yield return row;
 
             yield break;
@@ -301,6 +314,9 @@ internal static class RunCommand
 
         if (sourceValue is IEnumerable enumerable and not string)
         {
+            if (scalar)
+                throw new FormatException("The --scalar option requires a tabular source exposing exactly one column.");
+
             var enumerator = enumerable.GetEnumerator();
             try
             {
@@ -318,26 +334,27 @@ internal static class RunCommand
         throw new FormatException("The source supplied to 'run' returned a scalar value. Expected an IEnumerable or IDataReader.");
     }
 
-    private static IEnumerable<object?> EnumerateReaderRows(IDataReader reader, string sourcePath)
+    private static IEnumerable<object?> EnumerateReaderRows(IDataReader reader, string sourcePath, bool scalar)
     {
         var hasHeaderRecord = reader is DisposableDataReader wrappedReader && wrappedReader.HasHeaderRecord;
 
         if (hasHeaderRecord)
         {
-            foreach (var row in EnumerateCsvRows(reader, sourcePath))
+            foreach (var row in EnumerateCsvRows(reader, sourcePath, scalar))
                 yield return row;
 
             yield break;
         }
 
-        foreach (var row in EnumerateGenericReaderRows(reader, sourcePath))
+        foreach (var row in EnumerateGenericReaderRows(reader, sourcePath, scalar))
             yield return row;
     }
 
-    private static IEnumerable<object?> EnumerateGenericReaderRows(IDataReader reader, string sourcePath)
+    private static IEnumerable<object?> EnumerateGenericReaderRows(IDataReader reader, string sourcePath, bool scalar)
     {
         try
         {
+            ValidateScalarColumnCount(reader.FieldCount, sourcePath, scalar);
             while (true)
             {
                 bool hasRow;
@@ -353,7 +370,7 @@ internal static class RunCommand
                 if (!hasRow)
                     yield break;
 
-                yield return BuildLiteDataRow(reader);
+                yield return scalar ? GetValue(reader, 0) : BuildLiteDataRow(reader);
             }
         }
         finally
@@ -362,7 +379,7 @@ internal static class RunCommand
         }
     }
 
-    private static IEnumerable<object?> EnumerateCsvRows(IDataReader reader, string sourcePath)
+    private static IEnumerable<object?> EnumerateCsvRows(IDataReader reader, string sourcePath, bool scalar)
     {
         try
         {
@@ -382,6 +399,8 @@ internal static class RunCommand
             var expectedFields = reader.FieldCount;
             if (expectedFields == 0)
                 throw new FormatException($"CSV source '{sourcePath}' is empty. A header row is required.");
+
+            ValidateScalarColumnCount(expectedFields, sourcePath, scalar);
 
             var headers = new string[expectedFields];
             var headerSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -424,7 +443,7 @@ internal static class RunCommand
                     values[i] = value is DBNull ? null : value;
                 }
 
-                yield return new LiteDataRow(headers, values);
+                yield return scalar ? values[0] : new LiteDataRow(headers, values);
                 recordNumber++;
             }
         }
@@ -432,6 +451,18 @@ internal static class RunCommand
         {
             reader.Dispose();
         }
+    }
+
+    private static void ValidateScalarColumnCount(int fieldCount, string sourcePath, bool scalar)
+    {
+        if (scalar && fieldCount != 1)
+            throw new FormatException($"The --scalar option requires source '{sourcePath}' to contain exactly one column; found {fieldCount}.");
+    }
+
+    private static object? GetValue(IDataRecord record, int index)
+    {
+        var value = record.GetValue(index);
+        return value is DBNull ? null : value;
     }
 
     private static LiteDataRow BuildLiteDataRow(IDataReader reader)

--- a/docs/_docs/using-expressif-cli.md
+++ b/docs/_docs/using-expressif-cli.md
@@ -110,6 +110,7 @@ How `--source` works:
 - In CSV files, the first row is treated as the header (column names).
 - In CSV files, each following row is evaluated once.
 - In CSV files, use column names in expressions, for example `[name]` or `[age]`.
+- With `--scalar`, a source with exactly one column supplies each row as its scalar value instead of a record.
 - Non-CSV files (for example `.expr`) are evaluated as closed expressions.
 - A non-CSV source expression must return an enumerable.
 - Each direct element returned by a non-CSV source expression is evaluated once.
@@ -194,6 +195,14 @@ Examples:
 ```console
 expressif run "[country] | upper" --source customers.csv
 ```
+
+For a single-column source, use `--scalar` to unwrap each row while preserving one evaluation per row:
+
+```console
+expressif run "upper" --source names.csv --scalar
+```
+
+`--scalar` rejects sources with zero or multiple columns.
 
 ```console
 expressif run "absolute | add(1)" --source values.expr

--- a/docs/_docs/using-expressif-cli.md
+++ b/docs/_docs/using-expressif-cli.md
@@ -94,6 +94,22 @@ The result is written directly to standard output:
 
 The input is passed to the expression as text. The expression is responsible for interpreting or converting it as needed.
 
+### Evaluating a complete CSV source
+
+Use `--source` (alias: `-s`) to evaluate once against an array containing every CSV row. By default, rows are records whose field names come from the header:
+
+```console
+expressif evaluate "count" --source people.csv
+```
+
+For a single-column CSV, `--scalar` creates an array of scalar values instead:
+
+```console
+expressif evaluate "map(upper)" --source names.csv --scalar
+```
+
+A header-only CSV supplies an empty array and is still evaluated once. `--source` cannot be combined with `--input`, and `--scalar` requires exactly one source column.
+
 ## Running an expression over a sequence
 
 Use `run` to evaluate an expression repeatedly over an input sequence.
@@ -128,6 +144,7 @@ In this example, there is one row (the array value `{1, -2, 3}`), not three rows
 The `run` command differs from `evaluate`:
 
 - `evaluate` executes once for a single input value;
+- `evaluate --source` executes once for an array containing all source rows;
 - `run` executes once per generated row.
 
 You can pass `--input` multiple times. Each occurrence contributes one row.


### PR DESCRIPTION
## Summary

- add `--scalar` source-row unwrapping to `expressif run`
- allow `expressif evaluate --source` to evaluate once against the complete CSV dataset
- share CSV parsing, typing, and single-column validation across both commands
- document the distinct row and array semantics

## Root cause and impact

The CLI source pipeline only exposed row-oriented evaluation through `run`. It had no supported way to unwrap a single-column row, and `evaluate` could not consume a CSV source as one array. These changes add both shapes while preserving existing record behavior.

## Validation

- `dotnet build Expressif.Cli.Tests/Expressif.Cli.Tests.csproj --no-restore --nologo -m:1 -p:UseSharedCompilation=false`
- `dotnet test Expressif.Cli.Tests/Expressif.Cli.Tests.csproj --no-build --no-restore --nologo -m:1`
- 73 tests passed

Closes #474
Closes #475