### PR TITLE
fix(cli): reject invalid record inputs

### DIFF
--- a/Expressif.Cli.Tests/CliCommandTests.cs
+++ b/Expressif.Cli.Tests/CliCommandTests.cs
@@ -571,6 +571,19 @@ public class CliCommandTests
     }
 
     [Test]
+    public async Task Run_InputRecordWithDuplicateFields_ReturnsClearError()
+    {
+        var result = await InvokeAsync("run", "count", "--input", "{name := alice, name := bob}");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.EvaluationFailed));
+            Assert.That(result.StdOut, Is.Empty);
+            Assert.That(result.StdErr.Trim(), Is.EqualTo("Duplicate field 'name' in record literal."));
+        });
+    }
+
+    [Test]
     public async Task Run_BatchOption_ScalarValue_ReturnsClearEnumerableError()
     {
         var result = await InvokeAsync("run", "add(1)", "--batch", "42");

--- a/Expressif.Cli.Tests/CliCommandTests.cs
+++ b/Expressif.Cli.Tests/CliCommandTests.cs
@@ -584,6 +584,19 @@ public class CliCommandTests
     }
 
     [Test]
+    public async Task Run_BatchOption_RecordValue_ReturnsClearEnumerableError()
+    {
+        var result = await InvokeAsync("run", "count", "--batch", "{name := alice, age := 32}");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.InvalidExpressionOrInput));
+            Assert.That(result.StdOut, Is.Empty);
+            Assert.That(result.StdErr.Trim(), Is.EqualTo("The --batch option requires an enumerable value."));
+        });
+    }
+
+    [Test]
     public async Task Run_SourceEnumerableExpression_EvaluatesEachRow()
     {
         var sourcePath = CreateTempFile("{1, -2, 3}");

--- a/Expressif.Cli/Commands/RunCommand.cs
+++ b/Expressif.Cli/Commands/RunCommand.cs
@@ -621,7 +621,12 @@ internal static class RunCommand
         {
             var value = new RecordValue();
             foreach (var field in record.Fields)
+            {
+                if (value.ContainsKey(field.Name))
+                    throw new ArgumentException($"Duplicate field '{field.Name}' in record literal.");
+
                 value.Set(field.Name, ConvertToRuntimeValue(field.Value));
+            }
 
             return value;
         }

--- a/Expressif.Cli/Commands/RunCommand.cs
+++ b/Expressif.Cli/Commands/RunCommand.cs
@@ -255,7 +255,7 @@ internal static class RunCommand
             throw new FormatException($"Invalid input syntax for --batch '{batchInput}': {exception.Message}", exception);
         }
 
-        if (parsedBatchInput is not IEnumerable enumerable || parsedBatchInput is string)
+        if (parsedBatchInput is not IEnumerable enumerable || parsedBatchInput is string or RecordValue)
             throw new FormatException("The --batch option requires an enumerable value.");
 
         var enumerator = enumerable.GetEnumerator();


### PR DESCRIPTION
## Summary

- reject a single record passed to `--batch` instead of treating its fields as rows
- reject duplicate fields while converting CLI record literals
- add regression coverage for both cases

## Root cause

`RecordValue` implements `IEnumerable`, so the batch guard accepted records. Separately, CLI record conversion called `RecordValue.Set` without checking for an existing field, silently overwriting duplicates.

## Impact

Record inputs now follow the same validation rules as record expression construction, and `--batch` accepts row collections rather than a single record.

## Validation

- `git diff --check` passed
- targeted tests were added
- local test execution is currently blocked because NuGet cannot retrieve `System.CommandLine` due a TLS credential failure in the environment

Closes #473
Closes #476