### PR TITLE
docs: complete array and record function documentation

### DIFF
--- a/Expressif/Functions/Array/Filter.cs
+++ b/Expressif/Functions/Array/Filter.cs
@@ -16,6 +16,7 @@ public class Filter : BaseArrayFunction
 {
     public Func<IPredicate> Predicate { get; }
 
+    /// <param name="predicate">Factory that creates the predicate applied to each input item.</param>
     public Filter(Func<IPredicate> predicate)
         => Predicate = predicate;
 

--- a/Expressif/Functions/Array/Filter.cs
+++ b/Expressif/Functions/Array/Filter.cs
@@ -16,7 +16,7 @@ public class Filter : BaseArrayFunction
 {
     public Func<IPredicate> Predicate { get; }
 
-    /// <param name="predicate">Factory that creates the predicate applied to each input item.</param>
+    /// <param name="predicate">Expression defining the predicate applied to each input item.</param>
     public Filter(Func<IPredicate> predicate)
         => Predicate = predicate;
 

--- a/Expressif/Functions/Array/Map.cs
+++ b/Expressif/Functions/Array/Map.cs
@@ -15,6 +15,7 @@ public class Map : BaseArrayFunction
 {
     public Func<IFunction> Transformation { get; }
 
+    /// <param name="transformation">Factory that creates the transformation applied to each input item.</param>
     public Map(Func<IFunction> transformation)
         => Transformation = transformation;
 

--- a/Expressif/Functions/Array/Map.cs
+++ b/Expressif/Functions/Array/Map.cs
@@ -15,7 +15,7 @@ public class Map : BaseArrayFunction
 {
     public Func<IFunction> Transformation { get; }
 
-    /// <param name="transformation">Factory that creates the transformation applied to each input item.</param>
+    /// <param name="transformation">Expression creating the transformation applied to each input item.</param>
     public Map(Func<IFunction> transformation)
         => Transformation = transformation;
 

--- a/Expressif/Functions/Array/SelectionFunctions.cs
+++ b/Expressif/Functions/Array/SelectionFunctions.cs
@@ -5,11 +5,16 @@ using Expressif.Functions;
 
 namespace Expressif.Functions.Array;
 
+/// <summary>
+/// Returns up to the requested number of elements from the start of the input enumerable.
+/// Returns <see langword="null"/> when the input is not an enumerable, is a string, or the count is negative.
+/// </summary>
 [Function(prefix: "", aliases: ["first"])]
 public class FirstElements : BaseArrayFunction
 {
     public Func<int> Count { get; }
 
+    /// <param name="count">Number of elements to return from the start of the input.</param>
     public FirstElements(Func<int> count)
         => Count = count;
 
@@ -34,11 +39,16 @@ public class FirstElements : BaseArrayFunction
     }
 }
 
+/// <summary>
+/// Omits the requested number of elements from the start of the input enumerable and returns the remainder.
+/// Returns <see langword="null"/> when the input is not an enumerable, is a string, or the count is negative.
+/// </summary>
 [Function(prefix: "", aliases: ["skip-first"])]
 public class SkipFirstElements : BaseArrayFunction
 {
     public Func<int> Count { get; }
 
+    /// <param name="count">Number of elements to omit from the start of the input.</param>
     public SkipFirstElements(Func<int> count)
         => Count = count;
 
@@ -62,11 +72,16 @@ public class SkipFirstElements : BaseArrayFunction
     }
 }
 
+/// <summary>
+/// Returns up to the requested number of elements from the end of the input enumerable, preserving their order.
+/// Returns <see langword="null"/> when the input is not an enumerable, is a string, or the count is negative.
+/// </summary>
 [Function(prefix: "", aliases: ["last"])]
 public class LastElements : BaseArrayFunction
 {
     public Func<int> Count { get; }
 
+    /// <param name="count">Number of elements to return from the end of the input.</param>
     public LastElements(Func<int> count)
         => Count = count;
 
@@ -92,11 +107,16 @@ public class LastElements : BaseArrayFunction
     }
 }
 
+/// <summary>
+/// Omits the requested number of elements from the end of the input enumerable and returns the remainder.
+/// Returns <see langword="null"/> when the input is not an enumerable, is a string, or the count is negative.
+/// </summary>
 [Function(prefix: "", aliases: ["skip-last"])]
 public class SkipLastElements : BaseArrayFunction
 {
     public Func<int> Count { get; }
 
+    /// <param name="count">Number of elements to omit from the end of the input.</param>
     public SkipLastElements(Func<int> count)
         => Count = count;
 
@@ -128,12 +148,18 @@ public class SkipLastElements : BaseArrayFunction
     }
 }
 
+/// <summary>
+/// Returns the elements in the zero-based half-open range from <c>start</c>, inclusive, to <c>end</c>, exclusive.
+/// Returns <see langword="null"/> when the input is not an enumerable, is a string, or either bound is negative.
+/// </summary>
 [Function(prefix: "", aliases: ["slice"])]
 public class SliceElements : BaseArrayFunction
 {
     public Func<int> Start { get; }
     public Func<int> End { get; }
 
+    /// <param name="start">Zero-based index of the first element to return.</param>
+    /// <param name="end">Zero-based exclusive index at which to stop returning elements.</param>
     public SliceElements(Func<int> start, Func<int> end)
         => (Start, End) = (start, end);
 

--- a/Expressif/Functions/Record/RecordFunctions.cs
+++ b/Expressif/Functions/Record/RecordFunctions.cs
@@ -5,11 +5,16 @@ using ValueRecord = Expressif.Values.RecordValue;
 
 namespace Expressif.Functions.Record;
 
+/// <summary>
+/// Returns the value of the named field from the input record or object.
+/// Returns <see langword="null"/> when the field does not exist or the input does not expose named values.
+/// </summary>
 [Function(prefix: "")]
 public class Field : IFunction
 {
     private Func<string> Name { get; }
 
+    /// <param name="name">Name of the field to retrieve from the input.</param>
     public Field(Func<string> name)
         => Name = name;
 
@@ -17,6 +22,10 @@ public class Field : IFunction
         => NamedValueAccessor.Get(value, Name.Invoke());
 }
 
+/// <summary>
+/// Creates a record by evaluating its named and spread entries against the input value.
+/// Later entries overwrite fields with the same name created by earlier entries.
+/// </summary>
 [Function(prefix: "")]
 public class Record : IFunction
 {
@@ -25,6 +34,7 @@ public class Record : IFunction
     public Record()
         : this(() => []) { }
 
+    /// <param name="entries">Factory that creates the named and spread entries used to build the record.</param>
     public Record(Func<RecordEntryEvaluator[]> entries)
         => Entries = entries;
 


### PR DESCRIPTION
## What changed

- document the array selection functions and their parameters
- document `filter` and `map` constructor parameters
- document the `field` and `record` functions and their parameters

## Why

Function introspection reads C# XML documentation to populate summaries and parameter descriptions. These functions were missing some or all of that inline documentation, which left their generated descriptions incomplete.

## Impact

Array and record functions now expose consistent summaries and parameter guidance through introspection and generated documentation. Runtime behavior is unchanged.

## Validation

- `git diff --check`
- `dotnet build Expressif/Expressif.csproj --no-restore --nologo -f net8.0 -p:NoWarn=NU1900 -p:UseSharedCompilation=false`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added XML documentation for array filtering, mapping, and selection functions.
  * Clarified handling of invalid inputs, range behavior, and constructor parameters.
  * Documented record fields, entry overwrite behavior, and record construction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->