### PR TITLE
feat: add map and field access shorthands

### DIFF
--- a/Expressif.Testing/ExpressionTest.cs
+++ b/Expressif.Testing/ExpressionTest.cs
@@ -359,6 +359,81 @@ public class ExpressionTest
     }
 
     [Test]
+    public void Evaluate_FieldShorthand_IsEquivalentToFieldFunction()
+    {
+        var input = new Dictionary<string, object?> { ["name"] = "Alice" };
+
+        Assert.That(new Expression(".name").Evaluate(input),
+            Is.EqualTo(new Expression("field(name)").Evaluate(input)));
+    }
+
+    [Test]
+    public void Evaluate_FieldShorthand_NestedPipeline_ReadsNestedField()
+    {
+        var input = new Dictionary<string, object?>
+        {
+            ["address"] = new Dictionary<string, object?> { ["city"] = "Brussels" }
+        };
+
+        Assert.That(new Expression(".address | .city").Evaluate(input), Is.EqualTo("Brussels"));
+    }
+
+    [Test]
+    public void Evaluate_FieldShorthand_MapAndFilter_UsesEachItemAsInput()
+    {
+        var context = new Context();
+        context.CurrentObject.Set(new
+        {
+            customers = new object?[]
+            {
+                new Dictionary<string, object?> { ["name"] = "Alice", ["active"] = true },
+                new Dictionary<string, object?> { ["name"] = "Bob", ["active"] = false }
+            }
+        });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(new ClosedExpression("[customers] |> (.name)", context).Evaluate(),
+                Is.EqualTo(new object?[] { "Alice", "Bob" }));
+            Assert.That(new ClosedExpression("[customers] | filter(.active) |> (.name)", context).Evaluate(),
+                Is.EqualTo(new object?[] { "Alice" }));
+        });
+    }
+
+    [Test]
+    public void Evaluate_FieldShorthand_RecordConstruction_UsesIncomingRecord()
+    {
+        var input = new Dictionary<string, object?> { ["name"] = "Alice" };
+        var result = (RecordValue)new Expression("record(customer-name := .name)").Evaluate(input)!;
+
+        Assert.That(result["customer-name"], Is.EqualTo("Alice"));
+    }
+
+    [Test]
+    public void Evaluate_FieldShorthand_NullField_ReturnsNull()
+    {
+        var input = new Dictionary<string, object?> { ["name"] = null };
+
+        Assert.That(new Expression(".name").Evaluate(input), Is.Null);
+    }
+
+    [TestCaseSource(nameof(FieldShorthandEdgeCases))]
+    public void Evaluate_FieldShorthand_EdgeCasesMatchLongForm(object? input)
+    {
+        var longForm = Assert.Catch(() => new Expression("field(name)").Evaluate(input));
+        var shorthand = Assert.Catch(() => new Expression(".name").Evaluate(input));
+
+        Assert.That(shorthand, Is.TypeOf(longForm!.GetType()));
+    }
+
+    private static IEnumerable<TestCaseData> FieldShorthandEdgeCases()
+    {
+        yield return new TestCaseData(new Dictionary<string, object?>()).SetName("Missing field");
+        yield return new TestCaseData("not a record").SetName("Non-record input");
+        yield return new TestCaseData(null).SetName("Null input");
+    }
+
+    [Test]
     public void Evaluate_Record_WithSpreadAndOverride_PreservesOrderAndOverridesLast()
     {
         var input = new Dictionary<string, object?>

--- a/Expressif.Testing/ExpressionTest.cs
+++ b/Expressif.Testing/ExpressionTest.cs
@@ -270,6 +270,15 @@ public class ExpressionTest
     }
 
     [Test]
+    public void Evaluate_ArrayMapShorthandPipeline_Valid()
+    {
+        var expression = new ClosedExpression("{-1,2,-3} |> (absolute | add(5)) | reverse");
+        var result = expression.Evaluate();
+
+        Assert.That(result, Is.EqualTo(new object?[] { 8m, 7m, 6m }));
+    }
+
+    [Test]
     public void Evaluate_StringArrayPipeMapUpper_Valid()
     {
         var expression = new ClosedExpression("{\"alice\",\"bob\"} | map(upper)");

--- a/Expressif.Testing/Parsers/ExpressionTest.cs
+++ b/Expressif.Testing/Parsers/ExpressionTest.cs
@@ -58,4 +58,24 @@ public class ExpressionTest
     [TestCase("{1,2,3,4} | filter(greater-than(2))", typeof(ClosedRootExpression))]
     public void Parse_RootExpression_ClosedFirst(string value, Type expectedType)
         => Assert.That(RootExpression.Parser.Parse(value), Is.TypeOf(expectedType));
+
+    [Test]
+    public void Parse_MapShorthand_LowersToMapFunction()
+    {
+        var expression = Expressif.Parsers.ClosedExpression.Parser.End()
+            .Parse("{1,2,3} |> (absolute | add(5)) | reverse");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(expression.Members.Select(x => x.Name), Is.EqualTo(new[] { "map", "reverse" }));
+            Assert.That(expression.Members.First().Syntax, Is.EqualTo(FunctionSyntax.MapShorthand));
+            Assert.That(((OpenExpressionParameter)expression.Members.First().Parameters.Single()).Expression.Members.Count(), Is.EqualTo(2));
+        });
+    }
+
+    [TestCase("{1,2,3} |> absolute")]
+    [TestCase("{1,2,3} |> ()")]
+    [TestCase("{1,2,3} |> (absolute")]
+    public void Parse_MapShorthandWithoutParenthesizedExpression_Invalid(string value)
+        => Assert.That(() => Expressif.Parsers.ClosedExpression.Parser.End().Parse(value), Throws.TypeOf<ParseException>());
 }

--- a/Expressif.Testing/Parsers/FunctionTest.cs
+++ b/Expressif.Testing/Parsers/FunctionTest.cs
@@ -7,6 +7,29 @@ namespace Expressif.Testing.Parsers;
 
 public class FunctionTest
 {
+    [TestCase(".name", "name")]
+    [TestCase(".birth-date", "birth-date")]
+    [TestCase(".amount+tax", "amount+tax")]
+    public void Parse_FieldShorthand_LowersToFieldFunction(string value, string expectedName)
+    {
+        var function = Expressif.Parsers.Function.Parser.End().Parse(value);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(function.Name, Is.EqualTo("field"));
+            Assert.That(function.Syntax, Is.EqualTo(FunctionSyntax.FieldShorthand));
+            Assert.That(((LiteralParameter)function.Parameters.Single()).Value, Is.EqualTo(expectedName));
+        });
+    }
+
+    [TestCase(".")]
+    [TestCase(". name")]
+    [TestCase(".5")]
+    [TestCase(".\"name\"")]
+    [TestCase(".`name`")]
+    public void Parse_InvalidFieldShorthand_ThrowsParseException(string value)
+        => Assert.That(() => Expressif.Parsers.Function.Parser.End().Parse(value), Throws.TypeOf<ParseException>());
+
     [SetUp]
     public void Setup()
     { }

--- a/Expressif.Testing/Serializer/ExpressionSerializerTest.cs
+++ b/Expressif.Testing/Serializer/ExpressionSerializerTest.cs
@@ -1,5 +1,6 @@
 ﻿using Expressif.Parsers;
 using Expressif.Serializers;
+using Sprache;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -60,6 +61,16 @@ public class ExpressionSerializerTest
         var expression = new Expressif.Parsers.ClosedExpression(new VariableParameter("arr"), [new Function("count", [])]);
 
         Assert.That(new ExpressionSerializer().Serialize(expression), Is.EqualTo("@arr | count"));
+    }
+
+    [Test]
+    public void Serialize_MapShorthand_PreservesShorthand()
+    {
+        var expression = Expressif.Parsers.ClosedExpression.Parser.End()
+            .Parse("{1,2,3} |> (absolute | add(5)) | reverse");
+
+        Assert.That(new ExpressionSerializer().Serialize(expression),
+            Is.EqualTo("{1, 2, 3} |> (absolute | add(5)) | reverse"));
     }
 
     [Test]

--- a/Expressif.Testing/Serializer/FunctionSerializerTest.cs
+++ b/Expressif.Testing/Serializer/FunctionSerializerTest.cs
@@ -1,5 +1,6 @@
 ﻿using Expressif.Parsers;
 using Expressif.Serializers;
+using Sprache;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -10,6 +11,21 @@ namespace Expressif.Testing.Serializers;
 
 public class FunctionSerializerTest
 {
+    [Test]
+    public void Serialize_FieldShorthand_PreservesShorthand()
+    {
+        var function = Expressif.Parsers.Function.Parser.End().Parse(".name");
+
+        Assert.That(new FunctionSerializer().Serialize(function), Is.EqualTo(".name"));
+    }
+
+    [Test]
+    public void Serialize_DynamicFieldName_PreservesLongForm()
+    {
+        var function = Expressif.Parsers.Function.Parser.End().Parse("field([requested-field])");
+
+        Assert.That(new FunctionSerializer().Serialize(function), Is.EqualTo("field([requested-field])"));
+    }
     [Test]
     public void Serialize_NoParameter_NoParenthesis()
     {

--- a/Expressif/Functions/ExpressionFactory.cs
+++ b/Expressif/Functions/ExpressionFactory.cs
@@ -279,12 +279,27 @@ public class ExpressionFactory : BaseExpressionFactory
         static Func<IPredicate> BuildSinglePredicateFromOpenExpression(OpenExpressionParameter openExpression, PredicationFactory factory, IContext context, string functionName)
         {
             var members = openExpression.Expression.Members.ToArray();
+            if (members.Any(x => x.Syntax == FunctionSyntax.FieldShorthand))
+            {
+                var functions = members.Select(member => new ExpressionFactory().Instantiate(member.Name, member.Parameters, context)).ToArray();
+                return () => new BooleanExpressionPredicate(new ChainFunction(functions));
+            }
+
             if (members.Length != 1)
                 throw new MissingOrUnexpectedParametersFunctionException(functionName, members.Length);
 
-            var predication = new SinglePredication(members[0]);
+            var predication = new SinglePredication(members.Single());
             return () => factory.Instantiate(predication, context);
         }
+    }
+
+    private sealed class BooleanExpressionPredicate(IFunction expression) : IPredicate
+    {
+        public bool Evaluate(object? value)
+            => expression.Evaluate(value) is true;
+
+        object? IFunction.Evaluate(object? value)
+            => Evaluate(value);
     }
 
     private Func<string> BuildAccumulatorNameProvider(IParameter parameter, IContext context)

--- a/Expressif/Parsers/Expression.cs
+++ b/Expressif/Parsers/Expression.cs
@@ -15,12 +15,20 @@ public class OpenExpression : IExpression
     public OpenExpression(IEnumerable<Function> members)
         => (Members) = (members);
 
+    private static readonly Parser<Function> MapShorthandParser =
+        from _ in Parse.String("|>").Token()
+        from expression in Parse.Ref(() => Parser).Contained(Parse.Char('(').Token(), Parse.Char(')').Token())
+        select new Function("map", [new OpenExpressionParameter(expression)], FunctionSyntax.MapShorthand);
+
+    internal static readonly Parser<Function> ContinuationParser =
+        MapShorthandParser.Or(
+            from _ in Parse.Char('|').Token()
+            from function in Function.Parser.Token()
+            select function);
+
     public static readonly Parser<OpenExpression> Parser =
         from first in Function.Parser.Once()
-        from others in (
-            from _ in Parse.Char('|').Token()
-            from p in Function.Parser.Token()
-            select p).Many()
+        from others in ContinuationParser.Many()
         select new OpenExpression(first.Concat(others));
 }
 
@@ -51,12 +59,8 @@ public class ClosedExpression : IExpression
 
     private static readonly Parser<ClosedExpression> AnyRootParser =
         from parameter in Parsers.Parameter.Parser.Token()
-        from remaining in (
-            from _ in Parse.Char('|').Token()
-            from expression in OpenExpression.Parser
-            select expression.Members
-        ).Optional()
-        select new ClosedExpression(parameter, remaining.GetOrElse(Enumerable.Empty<Function>()));
+        from remaining in OpenExpression.ContinuationParser.Many()
+        select new ClosedExpression(parameter, remaining);
 
     public static readonly Parser<ClosedExpression> Parser =
         AnyRootParser;

--- a/Expressif/Parsers/Function.cs
+++ b/Expressif/Parsers/Function.cs
@@ -9,7 +9,8 @@ namespace Expressif.Parsers;
 public enum FunctionSyntax
 {
     Standard,
-    MapShorthand
+    MapShorthand,
+    FieldShorthand
 }
 
 public class Function : IExpression
@@ -46,16 +47,28 @@ public class Function : IExpression
             ? Array.Empty<IParameter>()
             : [new RecordDefinitionParameter(entries)];
 
-    public static readonly Parser<Function> Parser =
+    private static readonly Parser<Function> FieldShorthandParser =
+        from _ in Parse.Char('.')
+        from name in Parse.Regex("[A-Za-z_][A-Za-z0-9_+\\-]*").Text()
+        select new Function("field", [new LiteralParameter(name)], FunctionSyntax.FieldShorthand);
+
+    private static readonly Parser<IParameter[]> FieldShorthandParametersParser =
+        from function in FieldShorthandParser.Contained(Parse.Char('(').Token(), Parse.Char(')').Token())
+        select new IParameter[] { new OpenExpressionParameter(new OpenExpression([function])) };
+
+    private static readonly Parser<Function> StandardParser =
         from functionName in Grammar.FunctionName
         from parameters in (functionName.Equals("filter", StringComparison.OrdinalIgnoreCase)
-                                ? PredicationParametersParser.Optional()
+                                ? FieldShorthandParametersParser.Or(PredicationParametersParser).Optional()
                                 : functionName.Equals("map", StringComparison.OrdinalIgnoreCase)
                                 ? OpenExpressionParametersParser.Optional()
                                 : functionName.Equals("record", StringComparison.OrdinalIgnoreCase)
                                 ? RecordParametersParser.Optional()
                                 : Parsers.Parameters.Parser.Optional())
         select new Function(functionName, parameters.GetOrElse(Array.Empty<IParameter>()));
+
+    public static readonly Parser<Function> Parser =
+        FieldShorthandParser.Or(StandardParser);
 
     public string Name { get; }
     public IParameter[] Parameters { get; }

--- a/Expressif/Parsers/Function.cs
+++ b/Expressif/Parsers/Function.cs
@@ -6,6 +6,12 @@ using System.Text;
 
 namespace Expressif.Parsers;
 
+public enum FunctionSyntax
+{
+    Standard,
+    MapShorthand
+}
+
 public class Function : IExpression
 {
     private static readonly Parser<IParameter[]> OpenExpressionParametersParser =
@@ -53,7 +59,8 @@ public class Function : IExpression
 
     public string Name { get; }
     public IParameter[] Parameters { get; }
+    public FunctionSyntax Syntax { get; }
 
-    public Function(string name, IParameter[] parameters)
-        => (Name, Parameters) = (name, parameters);
+    public Function(string name, IParameter[] parameters, FunctionSyntax syntax = FunctionSyntax.Standard)
+        => (Name, Parameters, Syntax) = (name, parameters, syntax);
 }

--- a/Expressif/Serializers/ExpressionSerializer.cs
+++ b/Expressif/Serializers/ExpressionSerializer.cs
@@ -41,21 +41,35 @@ public class ExpressionSerializer
     public virtual void Serialize(Parsers.ClosedExpression expression, ref StringBuilder stringBuilder)
     {
         stringBuilder.Append(ParameterSerializer.Serialize(expression.Parameter));
-        if (!expression.Members.Any())
-            return;
-
-        stringBuilder.Append(" | ");
-        Serialize([.. expression.Members], ref stringBuilder);
+        SerializeContinuations(expression.Members, ref stringBuilder);
     }
 
     public virtual void Serialize(IExpression[] expressions, ref StringBuilder stringBuilder)
     {
-        foreach (var expression in expressions)
+        if (expressions.Length == 0)
+            return;
+
+        Serialize(expressions[0], ref stringBuilder);
+        SerializeContinuations(expressions.Skip(1).OfType<Function>(), ref stringBuilder);
+    }
+
+    private void SerializeContinuations(IEnumerable<Function> functions, ref StringBuilder stringBuilder)
+    {
+        foreach (var function in functions)
         {
-            Serialize(expression, ref stringBuilder);
-            stringBuilder.Append(" | ");
+            if (function.Syntax == FunctionSyntax.MapShorthand)
+            {
+                stringBuilder.Append(" |> (");
+                var expression = (OpenExpressionParameter)function.Parameters.Single();
+                Serialize(expression.Expression, ref stringBuilder);
+                stringBuilder.Append(')');
+            }
+            else
+            {
+                stringBuilder.Append(" | ");
+                Serialize(function, ref stringBuilder);
+            }
         }
-        stringBuilder.Remove(stringBuilder.Length - 3, 3);
     }
 
     public virtual string Serialize(IExpression expression)

--- a/Expressif/Serializers/FunctionSerializer.cs
+++ b/Expressif/Serializers/FunctionSerializer.cs
@@ -27,6 +27,12 @@ public class FunctionSerializer
 
     public virtual void Serialize(Function function, ref StringBuilder stringBuilder)
     {
+        if (function.Syntax == FunctionSyntax.FieldShorthand)
+        {
+            stringBuilder.Append('.').Append(((LiteralParameter)function.Parameters.Single()).Value);
+            return;
+        }
+
         stringBuilder.Append(function.Name.ToKebabCase());
         if (function.Parameters.Any())
         {

--- a/docs/_data/navigation_docs.yml
+++ b/docs/_data/navigation_docs.yml
@@ -11,6 +11,7 @@
 - title: Functions library
   docs:
   - flow-library-syntax
+  - shorthands
   - special-functions
   - text-functions
   - numeric-functions

--- a/docs/_docs/array-functions.md
+++ b/docs/_docs/array-functions.md
@@ -196,3 +196,13 @@ Returns the distinct values appearing in either the pipeline input or the specif
 * array: Specifies the second array whose values are combined with the pipeline input.
 
 <!-- END AUTO-GENERATED -->
+
+## Map shorthand
+
+Use `|> (...)` to apply a parenthesized expression to every item of an array. It is equivalent to `| map(...)`:
+
+```text
+{-1, 2, -3} |> (absolute | add(5)) | reverse
+```
+
+The parentheses are mandatory. The ordinary `|` after the closing parenthesis continues the pipeline with the complete mapped array, so the example applies `reverse` after mapping.

--- a/docs/_docs/flow-library-syntax.md
+++ b/docs/_docs/flow-library-syntax.md
@@ -12,7 +12,7 @@ The flow library and syntax define how data moves through a pipeline and how val
 The following constructs are complementary:
 
 * `[name]`: reads a field from the persistent current object.
-* `field(name)`: reads a field from the value entering the current stage.
+* `.name`: reads a field from the value entering the current stage (`field(name)` is the long form).
 * `record(...)`: constructs a new ordered record value.
 * `...`: represents the full incoming value.
 
@@ -20,21 +20,21 @@ The following constructs are complementary:
 
 `[name]` always reads from the current object associated with the execution context.
 
-`field(name)` always reads from the value entering the current pipeline stage.
+`.name` always reads from the value entering the current pipeline stage.
 
 Example:
 
 ```text
 [customer]
 | record(
-    customerName := field(name),
+    customerName := .name,
     requestedBy := [name]
 )
 ```
 
 In this expression:
 
-* `field(name)` reads from `[customer]` (the incoming stage value).
+* `.name` reads from `[customer]` (the incoming stage value).
 * `[name]` reads from the current object.
 
 ## The incoming-value expression: ...
@@ -90,6 +90,6 @@ Properties:
 
 ## field function
 
-`field(name)` retrieves a field from the incoming pipeline value.
+`.name` retrieves a field from the incoming pipeline value. It is shorthand for `field(name)`.
 
 It is useful inside `record(...)` to transform fields from the current stage input without relying on the current object.

--- a/docs/_docs/shorthands.md
+++ b/docs/_docs/shorthands.md
@@ -1,0 +1,83 @@
+---
+title: Shorthands
+subtitle: Concise forms supported by the Expressif parsers
+tags: [syntax, shorthand]
+keywords: [shorthand, field, map, interval, variable, property, index, spread]
+---
+
+Expressif provides concise syntax for common pipeline, field, parameter, interval, and predication operations.
+
+## Mapping each array item: `|> (...)`
+
+`|> (...)` is shorthand for `| map(...)`. The mapped expression must be enclosed in parentheses:
+
+```text
+[customers] |> (.name | upper) | reverse
+```
+
+This is equivalent to:
+
+```text
+[customers] | map(field(name) | upper) | reverse
+```
+
+The ordinary `|` following `)` resumes operations on the complete mapped array.
+
+## Reading an incoming field: `.name`
+
+`.name` is shorthand for `field(name)` and reads from the current input of that expression:
+
+```text
+[customers] |> (.name)
+[customers] | filter(.active)
+record(customer-name := .name, country := .country)
+```
+
+Field names may contain letters, digits after the first character, `_`, `-`, and `+`. There must be no whitespace after the dot. Use the long form for dynamic or quoted names:
+
+```text
+field([requested-field])
+field("customer name")
+```
+
+Compose nested access as a pipeline; dotted paths are not supported:
+
+```text
+.address | .city
+```
+
+## Parameters and incoming values
+
+| Shorthand | Meaning |
+|---|---|
+| `@name` | Context variable named `name` |
+| `[name]` | Field `name` on the persistent current object |
+| `#2` | Item at zero-based index `2` |
+| `...` | Complete incoming value |
+
+Inside `record(...)`, a standalone `...` spreads the incoming record. On the right of `:=`, it embeds the complete incoming value instead.
+
+## Interval shorthands
+
+Intervals have symbolic concise forms:
+
+| Shorthand | Interval |
+|---|---|
+| `(+)` | Strictly positive |
+| `(0+)` | Positive or zero |
+| `(-)` | Strictly negative |
+| `(0-)` | Negative or zero |
+| `(>5)` / `(>=5)` | Greater than / greater than or equal to `5` |
+| `(<5)` / `(<=5)` | Less than / less than or equal to `5` |
+
+The word forms `(positive)`, `(absolutely-positive)`, `(negative)`, and `(absolutely-negative)` are also accepted.
+
+## Predication operators
+
+`|?` starts a predication from an explicit input, `!` negates a predicate, and `|AND`, `|OR`, and `|XOR` combine predicates:
+
+```text
+@age |? !less-than(18) |AND less-than(65)
+```
+
+These operators are parser syntax; they do not register additional functions or predicates.


### PR DESCRIPTION
## Summary

- add `|> (...)` as shorthand for mapping an expression over an array
- add `.field-name` as shorthand for the existing `field(...)` function
- preserve both shorthand forms during serialization
- document the new syntax and cover parsing, evaluation, invalid syntax, and serialization

## Impact

Expressions that map over arrays or access record fields can now use concise pipeline-oriented syntax without introducing new runtime functions.

## Validation

- `git diff --check origin/main...HEAD` passed
- the .NET test runner was started, but hung before producing build or test output in the local environment

Closes #423
Closes #462