### PR TITLE
feat(temporal): add duration-between function

### DIFF
--- a/Expressif.Testing/ExpressionTest.cs
+++ b/Expressif.Testing/ExpressionTest.cs
@@ -129,6 +129,21 @@ public class ExpressionTest
     }
 
     [Test]
+    public void Evaluate_DurationBetween_Valid()
+    {
+        var expression = new Expression("duration-between(2026-08-06T10:30:00)", new Context());
+        var result = expression.Evaluate("2026-08-06T12:00:00");
+        Assert.That(result, Is.EqualTo(TimeSpan.FromMinutes(90)));
+    }
+
+    [Test]
+    public void Evaluate_DurationBetweenIncompatiblePrevious_Null()
+    {
+        var expression = new Expression("duration-between(invalid)", new Context());
+        Assert.That(expression.Evaluate("2026-08-06T12:00:00"), Is.Null);
+    }
+
+    [Test]
     public void Evaluate_CalendarCatholic_Valid()
     {
         var expression = new Expression("calendar-catholic(\"eAsTeR sUnDaY\")", new Context());

--- a/Expressif.Testing/Functions/Temporal/TemporalFunctionsTest.cs
+++ b/Expressif.Testing/Functions/Temporal/TemporalFunctionsTest.cs
@@ -15,6 +15,10 @@ namespace Expressif.Testing.Functions.Temporal;
 public class TemporalFunctionsTest
 {
     [Conformance]
+    public void DurationBetween_Valid_Previous(object input, object previous, TimeSpan? expected)
+        => Assert.That(new DurationBetween(() => previous).Evaluate(input), Is.EqualTo(expected));
+
+    [Conformance]
     public void Clamp_Valid(object value, DateTime min, DateTime max, DateTime expected)
         => Assert.That(new Clamp(() => min, () => max)
             .Evaluate(value), Is.EqualTo(expected));

--- a/Expressif/Functions/Temporal/TemporalFunctions.cs
+++ b/Expressif/Functions/Temporal/TemporalFunctions.cs
@@ -246,6 +246,32 @@ public class Clamp : BaseTemporalFunction
 }
 
 /// <summary>
+/// Returns the signed duration between the current temporal value and a previous temporal value. Returns `null` when either value cannot be evaluated or the temporal values are incompatible.
+/// </summary>
+[Function(prefix: "")]
+public class DurationBetween : BaseTemporalFunction
+{
+    public Func<object?> Previous { get; }
+
+    /// <param name="previous">The previous temporal value to subtract from the current input.</param>
+    public DurationBetween(Func<object?> previous)
+        => Previous = previous;
+
+    protected override object? EvaluateUncasted(object value)
+        => new DateTimeCaster().TryCast(value, out var dateTime)
+            ? EvaluateDateTime(dateTime)
+            : null;
+
+    protected override object EvaluateDateTime(DateTime value)
+    {
+        var previous = Previous.Invoke();
+        return previous is not null && new DateTimeCaster().TryCast(previous, out var dateTime)
+            ? value - dateTime
+            : null!;
+    }
+}
+
+/// <summary>
 /// Returns a dateTime with the time part set to the value passed as parameter and the date part corresponding to the argument value.
 /// </summary>
 public class SetTime : BaseTemporalFunction

--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ Once installed, Expressif files and code blocks will be highlighted automaticall
 |Temporal | day-of-month                        | dateTime-to-day-of-month                                                          |
 |Temporal | day-of-week                         | dateTime-to-day-of-week                                                           |
 |Temporal | day-of-year                         | dateTime-to-day-of-year                                                           |
+|Temporal | duration-between                    |                                                                                   |
 |Temporal | first-in-month                      | dateTime-to-first-in-month                                                        |
 |Temporal | first-of-month                      | dateTime-to-first-of-month                                                        |
 |Temporal | first-of-year                       | dateTime-to-first-of-year                                                         |

--- a/conformance/functions/temporal/duration-between.yaml
+++ b/conformance/functions/temporal/duration-between.yaml
@@ -1,0 +1,56 @@
+suite: temporal
+kind: function
+operator: duration-between
+tests:
+  - id: duration-between.valid.previous
+    cases:
+      - id: duration-between.valid.previous.date.later
+        value: 2026-08-06
+        expected: 1.00:00:00
+        parameters:
+          - 2026-08-05
+      - id: duration-between.valid.previous.date.earlier
+        value: 2026-08-05
+        expected: -1.00:00:00
+        parameters:
+          - 2026-08-06
+      - id: duration-between.valid.previous.date.equal
+        value: 2026-08-06
+        expected: 00:00:00
+        parameters:
+          - 2026-08-06
+      - id: duration-between.valid.previous.date-time.later
+        value: 2026-08-06T12:00:00
+        expected: 01:30:00
+        parameters:
+          - 2026-08-06T10:30:00
+      - id: duration-between.valid.previous.date-time.earlier
+        value: 2026-08-06T09:00:00
+        expected: -01:30:00
+        parameters:
+          - 2026-08-06T10:30:00
+      - id: duration-between.valid.previous.date-time.equal
+        value: 2026-08-06T10:30:00
+        expected: 00:00:00
+        parameters:
+          - 2026-08-06T10:30:00
+      - id: duration-between.valid.previous.special.null
+        value: (null)
+        expected:
+        parameters:
+          - 2026-08-06T10:30:00
+      - id: duration-between.valid.previous.special.empty
+        value: (empty)
+        expected:
+        parameters:
+          - 2026-08-06T10:30:00
+      - id: duration-between.valid.previous.text.incompatible-current
+        value: invalid
+        expected:
+        parameters:
+          - 2026-08-06T10:30:00
+      - id: duration-between.valid.previous.text.incompatible-previous
+        value: 2026-08-06T10:30:00
+        expected:
+        parameters:
+          - invalid

--- a/docs/_data/function.json
+++ b/docs/_data/function.json
@@ -2364,5 +2364,21 @@
     "Scope": "Text",
     "Summary": "Returns the argument string without white-space characters.",
     "Parameters": []
+  },
+  {
+    "Name": "duration-between",
+    "IsPublic": true,
+    "Aliases": [
+      "duration-between"
+    ],
+    "Scope": "Temporal",
+    "Summary": "Returns the signed duration between the current temporal value and a previous temporal value. Returns `null` when either value cannot be evaluated or the temporal values are incompatible.",
+    "Parameters": [
+      {
+        "Name": "previous",
+        "Optional": false,
+        "Summary": "The previous temporal value to subtract from the current input."
+      }
+    ]
   }
 ]

--- a/docs/_data/function.json
+++ b/docs/_data/function.json
@@ -958,6 +958,20 @@
     "Parameters": []
   },
   {
+    "Name": "duration-between",
+    "IsPublic": true,
+    "Aliases": [],
+    "Scope": "Temporal",
+    "Summary": "Returns the signed duration between the current temporal value and a previous temporal value. Returns `null` when either value cannot be evaluated or the temporal values are incompatible.",
+    "Parameters": [
+      {
+        "Name": "previous",
+        "Optional": false,
+        "Summary": "The previous temporal value to subtract from the current input."
+      }
+    ]
+  },
+  {
     "Name": "first-in-month",
     "IsPublic": true,
     "Aliases": [
@@ -2364,21 +2378,5 @@
     "Scope": "Text",
     "Summary": "Returns the argument string without white-space characters.",
     "Parameters": []
-  },
-  {
-    "Name": "duration-between",
-    "IsPublic": true,
-    "Aliases": [
-      "duration-between"
-    ],
-    "Scope": "Temporal",
-    "Summary": "Returns the signed duration between the current temporal value and a previous temporal value. Returns `null` when either value cannot be evaluated or the temporal values are incompatible.",
-    "Parameters": [
-      {
-        "Name": "previous",
-        "Optional": false,
-        "Summary": "The previous temporal value to subtract from the current input."
-      }
-    ]
   }
 ]

--- a/docs/_docs/library-index.md
+++ b/docs/_docs/library-index.md
@@ -54,6 +54,7 @@ tags: [predicates, functions]
 * [distinct]({{ site.baseurl }}/docs/array-functions/#distinct)
 * [divide]({{ site.baseurl }}/docs/numeric-functions/#divide)
 * [dot-case]({{ site.baseurl }}/docs/text-functions/#dot-case)
+* [duration-between]({{ site.baseurl }}/docs/temporal-functions/#duration-between)
 * [empty-to-null]({{ site.baseurl }}/docs/text-functions/#empty-to-null)
 * [extension]({{ site.baseurl }}/docs/io-functions/#extension)
 * [field]({{ site.baseurl }}/docs/record-functions/#field)

--- a/docs/_docs/temporal-functions.md
+++ b/docs/_docs/temporal-functions.md
@@ -2,7 +2,7 @@
 title: Temporal functions
 subtitle: Functions applicable to temporal values
 tags: [functions, temporal]
-keywords: [age, backward, catholic-calendar, ceiling-hour, ceiling-minute, change-of-hour, change-of-minute, change-of-month, change-of-second, change-of-year, clamp, datetime-to-date, day-of-month, day-of-week, day-of-year, first-in-month, first-of-month, first-of-year, floor-hour, floor-minute, forward, hour, hour-minute, hour-minute-second, hour-of-day, invalid-to-date, iso-day-of-year, iso-week-of-year, iso-year-day, iso-year-week, iso-year-week-day, last-in-month, last-of-month, last-of-year, length-of-month, length-of-year, local-to-utc, minute-of-day, minute-of-hour, month, month-day, month-of-year, next-business-days, next-day, next-month, next-weekday, next-weekday-or-same, next-year, null-to-date, previous-business-days, previous-day, previous-month, previous-weekday, previous-weekday-or-same, previous-year, second-of-day, second-of-hour, second-of-minute, set-time, set-to-local, set-to-utc, utc-to-local, year, year-of-era] # AUTO-GENERATED KEYWORDS
+keywords: [age, backward, catholic-calendar, ceiling-hour, ceiling-minute, change-of-hour, change-of-minute, change-of-month, change-of-second, change-of-year, clamp, datetime-to-date, day-of-month, day-of-week, day-of-year, duration-between, first-in-month, first-of-month, first-of-year, floor-hour, floor-minute, forward, hour, hour-minute, hour-minute-second, hour-of-day, invalid-to-date, iso-day-of-year, iso-week-of-year, iso-year-day, iso-year-week, iso-year-week-day, last-in-month, last-of-month, last-of-year, length-of-month, length-of-year, local-to-utc, minute-of-day, minute-of-hour, month, month-day, month-of-year, next-business-days, next-day, next-month, next-weekday, next-weekday-or-same, next-year, null-to-date, previous-business-days, previous-day, previous-month, previous-weekday, previous-weekday-or-same, previous-year, second-of-day, second-of-hour, second-of-minute, set-time, set-to-local, set-to-utc, utc-to-local, year, year-of-era] # AUTO-GENERATED KEYWORDS
 ---
 <!-- START AUTO-GENERATED -->
 ##### age
@@ -132,6 +132,14 @@ returns a numeric value representing the day of the week (1 being Monday and 7 b
 ###### Overview
 
 returns a numeric value representing the day position within the year of the date passed as the argument
+
+##### duration-between
+###### Overview
+
+Returns the signed duration between the current temporal value and a previous temporal value. Returns `null` when either value cannot be evaluated or the temporal values are incompatible.
+
+###### Parameter
+* previous: The previous temporal value to subtract from the current input.
 
 ##### first-in-month
 


### PR DESCRIPTION
## Summary

- add the public `duration-between(previous)` Temporal function
- preserve explicit `current - previous` operand order and return signed `TimeSpan` values
- return `null` for null, empty, or incompatible current/previous values
- add documentation metadata, conformance coverage, and parser-level tests

Closes #487

## Validation

- `dotnet build Expressif.Testing/Expressif.Testing.csproj --no-restore --disable-build-servers -m:1 --framework net8.0`
- `dotnet test Expressif.Testing/Expressif.Testing.csproj --no-restore --no-build --disable-build-servers -m:1 --framework net8.0`
- 2,751 passed, 1 skipped, 0 failed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `duration-between(previous)` temporal function.
  * Returns the signed duration between the current and previous date or date-time values.
  * Returns `null` when either value is missing, empty, or incompatible.

* **Documentation**
  * Added the function to the supported functions list, library index, and temporal-function documentation.

* **Tests**
  * Added coverage for later, earlier, equal, missing, and incompatible values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->