### PR TITLE
feat(tuple): add tuple values and adjacent operations

### DIFF
--- a/Expressif.Testing/Functions/Array/AdjacentTest.cs
+++ b/Expressif.Testing/Functions/Array/AdjacentTest.cs
@@ -1,0 +1,29 @@
+using System.Collections;
+
+namespace Expressif.Testing.Functions.Array;
+
+public class AdjacentTest
+{
+    [Test]
+    public void Expression_ShorthandSubtract_ReturnsDifferences()
+        => Assert.That(new Expression("adjacent(subtract)").Evaluate(new[] { 100, 105, 120 }), Is.EqualTo(new decimal?[] { 5, 15 }));
+
+    [Test]
+    public void Expression_OpenComposition_KeepsTupleProjectionsLexicallyBound()
+        => Assert.That(new Expression("adjacent($1 | subtract($0) | multiply($1))").Evaluate(new[] { 100, 105, 120 }),
+            Is.EqualTo(new decimal?[] { 525, 1800 }));
+
+    [Test]
+    public void Expression_PredicateShorthand_IsSupported()
+        => Assert.That(new Expression("adjacent(greater-than)").Evaluate(new[] { 100, 105, 90 }), Is.EqualTo(new[] { true, false }));
+
+    [Test]
+    public void Expression_Boundaries_ReturnEmptySequence()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(((IEnumerable)new Expression("adjacent(subtract)").Evaluate(System.Array.Empty<int>())!).Cast<object>(), Is.Empty);
+            Assert.That(((IEnumerable)new Expression("adjacent(subtract)").Evaluate(new[] { 1 })!).Cast<object>(), Is.Empty);
+        });
+    }
+}

--- a/Expressif.Testing/Functions/Array/PairwiseTest.cs
+++ b/Expressif.Testing/Functions/Array/PairwiseTest.cs
@@ -1,0 +1,59 @@
+using System.Collections;
+using Expressif.Functions.Array;
+using Expressif.Values;
+
+namespace Expressif.Testing.Functions.Array;
+
+public class PairwiseTest
+{
+    [Test]
+    public void Evaluate_Values_ReturnsConsecutiveTuples()
+        => Assert.That(new Pairwise().Evaluate(new object?[] { 100, 105, 120 }),
+            Is.EqualTo(new[] { new TupleValue(100, 105), new TupleValue(105, 120) }));
+
+    [TestCase(0, 0)]
+    [TestCase(1, 0)]
+    [TestCase(2, 1)]
+    public void Evaluate_Boundaries_CorrectCardinality(int count, int expected)
+        => Assert.That(((IEnumerable)new Pairwise().Evaluate(Enumerable.Range(0, count).ToArray())!).Cast<object>().Count(), Is.EqualTo(expected));
+
+    [Test]
+    public void Evaluate_Nulls_ArePreserved()
+        => Assert.That(new Pairwise().Evaluate(new object?[] { 100, null, 120 }),
+            Is.EqualTo(new[] { new TupleValue(100, null), new TupleValue(null, 120) }));
+
+    [Test]
+    public void Evaluate_IsProgressiveAndUsesOneEnumerator()
+    {
+        var source = new TrackingEnumerable(1, 2, 3);
+        var result = ((IEnumerable)new Pairwise().Evaluate(source)!).GetEnumerator();
+
+        Assert.That(source.MoveNextCalls, Is.Zero);
+        Assert.That(result.MoveNext(), Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(source.GetEnumeratorCalls, Is.EqualTo(1));
+            Assert.That(source.MoveNextCalls, Is.EqualTo(2));
+            Assert.That(result.Current, Is.EqualTo(new TupleValue(1, 2)));
+        });
+    }
+
+    private sealed class TrackingEnumerable(params object?[] values) : IEnumerable
+    {
+        public int GetEnumeratorCalls { get; private set; }
+        public int MoveNextCalls { get; private set; }
+        public IEnumerator GetEnumerator()
+        {
+            GetEnumeratorCalls++;
+            return Enumerate().GetEnumerator();
+        }
+        private IEnumerable Enumerate()
+        {
+            foreach (var value in values)
+            {
+                MoveNextCalls++;
+                yield return value;
+            }
+        }
+    }
+}

--- a/Expressif.Testing/Functions/Special/TupleFunctionsTest.cs
+++ b/Expressif.Testing/Functions/Special/TupleFunctionsTest.cs
@@ -1,0 +1,21 @@
+using Expressif.Functions.Special;
+using Expressif.Values;
+
+namespace Expressif.Testing.Functions.Special;
+
+public class TupleFunctionsTest
+{
+    [Test]
+    public void Evaluate_Accessors_Valid()
+    {
+        var tuple = new TupleValue(10, 20, 30);
+        Assert.Multiple(() =>
+        {
+            Assert.That(new TupleFirst().Evaluate(tuple), Is.EqualTo(10));
+            Assert.That(new TupleSecond().Evaluate(tuple), Is.EqualTo(20));
+            Assert.That(new TupleAt(() => 2).Evaluate(tuple), Is.EqualTo(30));
+            Assert.That(new TupleAt(() => 3).Evaluate(tuple), Is.Null);
+            Assert.That(new TupleFirst().Evaluate(new object[] { 10, 20 }), Is.Null);
+        });
+    }
+}

--- a/Expressif.Testing/Parsers/ParameterTest.cs
+++ b/Expressif.Testing/Parsers/ParameterTest.cs
@@ -1,4 +1,5 @@
 using Expressif.Parsers;
+using Expressif.Values;
 using Sprache;
 
 namespace Expressif.Testing.Parsers;
@@ -23,6 +24,8 @@ public class ParameterTest
     [TestCase("{@foo}", typeof(ArrayParameter))]
     [TestCase("{ @foo, #1, [bar] }", typeof(ArrayParameter))]
     [TestCase("{ @foo | text-to-func(bar) }", typeof(InputExpressionParameter))]
+    [TestCase("T(10, 20)", typeof(TupleParameter))]
+    [TestCase("T(1, T(2, 3))", typeof(TupleParameter))]
     public void Parse_Parameter_Valid(string value, Type type)
         => Assert.That(Parameter.Parser.Parse(value), Is.TypeOf(type));
 
@@ -66,5 +69,18 @@ public class ParameterTest
             Assert.That(parsed, Is.TypeOf<RecordLiteralParameter>());
             Assert.That(((RecordLiteralParameter)parsed).Fields, Is.Empty);
         });
+    }
+
+    [TestCase("T()")]
+    [TestCase("T(10)")]
+    public void Parse_TupleWithFewerThanTwoFields_Invalid(string value)
+        => Assert.Throws<ParseException>(() => Parameter.Parser.End().Parse(value));
+
+    [Test]
+    public void Parse_TupleLiteral_RoundTripsThroughClosedExpression()
+    {
+        var value = new ClosedExpression("T(1, T(2, 3))").Evaluate();
+
+        Assert.That(ValueFormatter.Format(value), Is.EqualTo("T(1, T(2, 3))"));
     }
 }

--- a/Expressif.Testing/Values/TupleValueTest.cs
+++ b/Expressif.Testing/Values/TupleValueTest.cs
@@ -1,0 +1,35 @@
+using Expressif.Values;
+
+namespace Expressif.Testing.Values;
+
+public class TupleValueTest
+{
+    [Test]
+    public void Constructor_FewerThanTwoFields_Throws()
+        => Assert.Throws<ArgumentException>(() => new Expressif.Values.Tuple(1));
+
+    [Test]
+    public void Equality_SameNestedFields_EqualAndSameHashCode()
+    {
+        var left = new TupleValue(1, new TupleValue(2, "three"));
+        var right = new TupleValue(1, new TupleValue(2, "three"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(left, Is.EqualTo(right));
+            Assert.That(left.GetHashCode(), Is.EqualTo(right.GetHashCode()));
+        });
+    }
+
+    [Test]
+    public void Format_NestedTuple_UsesCanonicalSyntax()
+        => Assert.That(ValueFormatter.Format(new TupleValue(1, new TupleValue(2, 3))), Is.EqualTo("T(1, T(2, 3))"));
+
+    [Test]
+    public void PublicTuple_IsImmutableCanonicalValueType()
+    {
+        object actual = new Expressif.Values.Tuple(10, 20);
+        object expected = new Expressif.Values.Tuple(10, 20);
+        Assert.That(actual, Is.EqualTo(expected));
+    }
+}

--- a/Expressif/Functions/Array/Adjacent.cs
+++ b/Expressif/Functions/Array/Adjacent.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Expressif.Values;
+
+namespace Expressif.Functions.Array;
+
+/// <summary>
+/// Evaluates an operation against every consecutive pair of input values. Returns `null` when the input cannot be evaluated.
+/// </summary>
+[Function(prefix: "", aliases: ["adjacent"])]
+public class Adjacent : BaseArrayFunction
+{
+    public Func<IFunction> Operation { get; }
+
+    /// <param name="operation">Specifies the callable or open expression evaluated against each consecutive pair.</param>
+    public Adjacent(Func<IFunction> operation)
+        => Operation = operation;
+
+    protected override object? EvaluateArray(IEnumerable enumerable)
+    {
+        var pairs = new Pairwise().Evaluate(enumerable) as IEnumerable;
+        return pairs is null ? null : Enumerate(pairs, Operation.Invoke());
+    }
+
+    private static IEnumerable<object?> Enumerate(IEnumerable pairs, IFunction operation)
+    {
+        foreach (var pair in pairs)
+            yield return operation.Evaluate(pair);
+    }
+}

--- a/Expressif/Functions/Array/Pairwise.cs
+++ b/Expressif/Functions/Array/Pairwise.cs
@@ -1,0 +1,37 @@
+using System.Collections;
+using System.Collections.Generic;
+using Expressif.Values;
+
+namespace Expressif.Functions.Array;
+
+/// <summary>
+/// Returns each consecutive pair of input values as a tuple. Returns `null` when the input cannot be evaluated.
+/// </summary>
+[Function(prefix: "", aliases: ["pairwise"])]
+public class Pairwise : BaseArrayFunction
+{
+    protected override object? EvaluateArray(IEnumerable enumerable)
+        => Enumerate(enumerable);
+
+    private static IEnumerable<Expressif.Values.Tuple> Enumerate(IEnumerable source)
+    {
+        var enumerator = source.GetEnumerator();
+        try
+        {
+            if (!enumerator.MoveNext())
+                yield break;
+
+            var previous = enumerator.Current;
+            while (enumerator.MoveNext())
+            {
+                var current = enumerator.Current;
+                yield return new Expressif.Values.Tuple(previous, current);
+                previous = current;
+            }
+        }
+        finally
+        {
+            (enumerator as System.IDisposable)?.Dispose();
+        }
+    }
+}

--- a/Expressif/Functions/BaseExpressionFactory.cs
+++ b/Expressif/Functions/BaseExpressionFactory.cs
@@ -56,12 +56,14 @@ public abstract class BaseExpressionFactory
         return parameter switch
         {
             ArrayParameter array => CreateFunctionCast(() => BuildArray(array, context), scalarType),
+            TupleParameter tuple => CreateFunctionCast(() => BuildTuple(tuple, context), scalarType),
             RecordLiteralParameter record => CreateFunctionCast(() => BuildRecord(record, context), scalarType),
             InputExpressionParameter input => CreateDelegateCast(CreateInputExpression(input, scalarType, context), scalarType),
             IntervalParameter interval => CreateCast(buildInterval(interval.Value), scalarType),
             QuotedLiteralParameter quoted => CreateCast(quoted.Value, scalarType),
             LiteralParameter literal => CreateCast(literal.Value, scalarType),
             ObjectIndexParameter index => CreateFunctionCast(() => context.CurrentObject[index.Index], scalarType),
+            TupleProjectionParameter projection => CreateFunctionCast(() => context.CurrentObject.Value is TupleValue tuple && projection.Index < tuple.Count ? tuple[projection.Index] : null, scalarType),
             ObjectPropertyParameter prop => CreateFunctionCast(() => context.CurrentObject[prop.Name], scalarType),
             VariableParameter variable => CreateFunctionCast(() => context.Variables[variable.Name], scalarType),
             ContextParameter contextReference => CreateFunctionCast(() => contextReference.Function.Invoke(context), scalarType),
@@ -78,6 +80,18 @@ public abstract class BaseExpressionFactory
             }
 
             return values;
+        }
+
+        Expressif.Values.Tuple BuildTuple(TupleParameter tuple, IContext currentContext)
+        {
+            var values = new object?[tuple.Values.Length];
+            for (var i = 0; i < tuple.Values.Length; i++)
+            {
+                var elementFactory = CreateParameter(tuple.Values[i], typeof(object), currentContext);
+                values[i] = elementFactory.DynamicInvoke();
+            }
+
+            return new Expressif.Values.Tuple(values);
         }
 
         ValueRecord BuildRecord(RecordLiteralParameter record, IContext currentContext)

--- a/Expressif/Functions/ExpressionFactory.cs
+++ b/Expressif/Functions/ExpressionFactory.cs
@@ -86,6 +86,9 @@ public class ExpressionFactory : BaseExpressionFactory
         if (name.Equals("record", StringComparison.OrdinalIgnoreCase))
             return BuildRecordFunction(function, context);
 
+        if (name.Equals("adjacent", StringComparison.OrdinalIgnoreCase))
+            return BuildAdjacentFunction(function, context);
+
         if (ImplicitFoldAccumulators.Contains(name) && function.Parameters.Length == 0)
             return new Fold(() => name);
 
@@ -101,6 +104,78 @@ public class ExpressionFactory : BaseExpressionFactory
             return filtering;
 
         return Instantiate<IFunction>(type, function.Parameters, context);
+    }
+
+    private IFunction BuildAdjacentFunction(Parsers.Function function, IContext context)
+    {
+        if (function.Parameters.Length != 1 || function.Parameters[0] is not OpenExpressionParameter open)
+            throw new MissingOrUnexpectedParametersFunctionException(function.Name, function.Parameters.Length);
+
+        var members = open.Expression.Members.ToArray();
+        IFunction operation;
+        if (members.Length == 1 && members[0].Parameters.Length == 0 && TryBuildBinaryCallable(members[0].Name, context, out var callable))
+        {
+            operation = new ChainFunction([
+                InstantiateOrWrapAggregation(new Parsers.Function("tuple-at", [new LiteralParameter("1")]), context),
+                callable
+            ]);
+        }
+        else
+            operation = BuildOpenExpression(open.Expression, context);
+
+        return new Adjacent(() => new LexicallyBoundTupleFunction(operation, context));
+    }
+
+    private bool TryBuildBinaryCallable(string name, IContext context, out IFunction callable)
+    {
+        var parameterized = new Parsers.Function(name, [new TupleProjectionParameter(0)]);
+        try
+        {
+            var functionType = TypeMapper.Execute(name);
+            if (!functionType.GetConstructors().Any(x => x.GetParameters().Length == 1))
+            {
+                callable = null!;
+                return false;
+            }
+            callable = InstantiateOrWrapAggregation(parameterized, context);
+            return true;
+        }
+        catch (NotImplementedFunctionException)
+        {
+            try
+            {
+                var predicateType = new PredicateTypeMapper().Execute(name);
+                if (!predicateType.GetConstructors().Any(x => x.GetParameters().Length == 1))
+                {
+                    callable = null!;
+                    return false;
+                }
+                callable = new PredicationFactory().Instantiate(new SinglePredication(parameterized), context);
+                return true;
+            }
+            catch (NotImplementedFunctionException)
+            {
+                callable = null!;
+                return false;
+            }
+        }
+    }
+
+    private sealed class LexicallyBoundTupleFunction(IFunction expression, IContext context) : IFunction
+    {
+        public object? Evaluate(object? value)
+        {
+            var previous = context.CurrentObject.Value;
+            context.CurrentObject.Set(value);
+            try
+            {
+                return expression.Evaluate(value);
+            }
+            finally
+            {
+                context.CurrentObject.Set(previous);
+            }
+        }
     }
 
     private IFunction BuildRecordFunction(Parsers.Function function, IContext context)

--- a/Expressif/Functions/Special/TupleFunctions.cs
+++ b/Expressif/Functions/Special/TupleFunctions.cs
@@ -1,0 +1,43 @@
+using System;
+using Expressif.Values;
+
+namespace Expressif.Functions.Special;
+
+/// <summary>
+/// Returns the tuple field at the specified zero-based position. Returns `null` when the input is not a tuple or the position is out of range.
+/// </summary>
+[Function(prefix: "", aliases: ["tuple-at"])]
+public class TupleAt : IFunction
+{
+    public Func<int> Position { get; }
+
+    /// <param name="position">Specifies the zero-based position of the tuple field to return.</param>
+    public TupleAt(Func<int> position)
+        => Position = position;
+
+    public object? Evaluate(object? value)
+    {
+        var position = Position.Invoke();
+        return value is TupleValue tuple && position >= 0 && position < tuple.Count
+            ? tuple[position]
+            : null;
+    }
+}
+
+/// <summary>
+/// Returns the first field of a tuple. Returns `null` when the input is not a tuple.
+/// </summary>
+[Function(prefix: "", aliases: ["tuple-first"])]
+public class TupleFirst : TupleAt
+{
+    public TupleFirst() : base(() => 0) { }
+}
+
+/// <summary>
+/// Returns the second field of a tuple. Returns `null` when the input is not a tuple.
+/// </summary>
+[Function(prefix: "", aliases: ["tuple-second"])]
+public class TupleSecond : TupleAt
+{
+    public TupleSecond() : base(() => 1) { }
+}

--- a/Expressif/Parsers/Function.cs
+++ b/Expressif/Parsers/Function.cs
@@ -52,6 +52,11 @@ public class Function : IExpression
         from name in Parse.Regex("[A-Za-z_][A-Za-z0-9_+\\-]*").Text()
         select new Function("field", [new LiteralParameter(name)], FunctionSyntax.FieldShorthand);
 
+    private static readonly Parser<Function> TupleProjectionShorthandParser =
+        from _ in Parse.Char('$')
+        from index in Parse.Number
+        select new Function("tuple-at", [new LiteralParameter(index)]);
+
     private static readonly Parser<IParameter[]> FieldShorthandParametersParser =
         from function in FieldShorthandParser.Contained(Parse.Char('(').Token(), Parse.Char(')').Token())
         select new IParameter[] { new OpenExpressionParameter(new OpenExpression([function])) };
@@ -61,6 +66,7 @@ public class Function : IExpression
         from parameters in (functionName.Equals("filter", StringComparison.OrdinalIgnoreCase)
                                 ? FieldShorthandParametersParser.Or(PredicationParametersParser).Optional()
                                 : functionName.Equals("map", StringComparison.OrdinalIgnoreCase)
+                                  || functionName.Equals("adjacent", StringComparison.OrdinalIgnoreCase)
                                 ? OpenExpressionParametersParser.Optional()
                                 : functionName.Equals("record", StringComparison.OrdinalIgnoreCase)
                                 ? RecordParametersParser.Optional()
@@ -68,7 +74,7 @@ public class Function : IExpression
         select new Function(functionName, parameters.GetOrElse(Array.Empty<IParameter>()));
 
     public static readonly Parser<Function> Parser =
-        FieldShorthandParser.Or(StandardParser);
+        TupleProjectionShorthandParser.Or(FieldShorthandParser).Or(StandardParser);
 
     public string Name { get; }
     public IParameter[] Parameters { get; }

--- a/Expressif/Parsers/Parameter.cs
+++ b/Expressif/Parsers/Parameter.cs
@@ -14,8 +14,10 @@ public record class IntervalParameter(Interval Value) : IParameter { }
 public record class VariableParameter(string Name) : IParameter { }
 public record class ObjectPropertyParameter(string Name) : IParameter { }
 public record class ObjectIndexParameter(int Index) : IParameter { }
+public record class TupleProjectionParameter(int Index) : IParameter { }
 public record class ContextParameter(Func<IContext, object?> Function) : IParameter { }
 public record class ArrayParameter(IParameter[] Values) : IParameter { }
+public record class TupleParameter(IParameter[] Values) : IParameter { }
 public record class QuotedLiteralParameter(string Value) : IParameter { }
 public record class IncomingValueParameter() : IParameter { }
 
@@ -47,6 +49,11 @@ public class Parameter
         from _ in Parse.Char('#')
         from index in Parse.Number
         select new ObjectIndexParameter(int.Parse(index));
+
+    protected static readonly Parser<IParameter> TupleProjectionParameter =
+        from _ in Parse.Char('$')
+        from index in Parse.Number
+        select new TupleProjectionParameter(int.Parse(index));
 
     protected static readonly Parser<IParameter> IncomingParameter =
         from _ in Parse.String("...").Token()
@@ -81,6 +88,19 @@ public class Parameter
         )
         select new ArrayParameter(values);
 
+    public static readonly Parser<IParameter> TupleLiteralParser =
+        from _ in Parse.String("T(").Token()
+        from first in Parse.Ref(() => RecordValueParameter).Token()
+        from __ in Parse.Char(',').Token()
+        from second in Parse.Ref(() => RecordValueParameter).Token()
+        from others in (
+            from comma in Parse.Char(',').Token()
+            from value in Parse.Ref(() => RecordValueParameter).Token()
+            select value
+        ).Many()
+        from close in Parse.Char(')').Token()
+        select new TupleParameter(new[] { first, second }.Concat(others).ToArray());
+
     protected static readonly Parser<IParameter> RecordLiteralParameter =
         from _ in Parse.Char('{').Token()
         from fields in (
@@ -112,9 +132,11 @@ public class Parameter
     protected static readonly Parser<IParameter> RecordValueParameter =
         IncomingParameter
         .Or(Parse.Ref(() => RecordLiteralParameter))
+        .Or(Parse.Ref(() => TupleLiteralParser))
         .Or(Parse.Ref(() => ArrayLiteralParameter))
         .Or(Parse.Ref(() => VariableParameter))
         .Or(Parse.Ref(() => IntervalParameter))
+        .Or(TupleProjectionParameter)
         .Or(Parse.Ref(() => IndexParameter))
         .Or(Parse.Ref(() => ItemParameter))
         .Or(QuotedLiteralParameter)
@@ -151,8 +173,10 @@ public class Parameter
     public static readonly Parser<IParameter> Parser = 
         VariableParameter
         .Or(IntervalParameter)
+        .Or(TupleProjectionParameter)
         .Or(IndexParameter)
         .Or(ItemParameter)
+        .Or(TupleLiteralParser)
         .Or(RecordLiteralParameter)
         .Or(ArrayLiteralParameter)
         .Or(ParametrizedExpressionParameter)

--- a/Expressif/Parsers/RootExpression.cs
+++ b/Expressif/Parsers/RootExpression.cs
@@ -11,8 +11,13 @@ public record class ClosedRootExpression(ClosedExpression Expression) : IRootExp
 
 public static class RootExpression
 {
+    private static readonly Parser<IRootExpression> TupleLiteralParser =
+        from tuple in Parameter.TupleLiteralParser
+        select (IRootExpression)new ClosedRootExpression(new ClosedExpression(tuple, []));
+
     public static readonly Parser<IRootExpression> Parser =
-        OpenExpression.Parser.Select(x => (IRootExpression)new OpenRootExpression(x))
+        TupleLiteralParser
+        .Or(OpenExpression.Parser.Select(x => (IRootExpression)new OpenRootExpression(x)))
         .Or(ClosedExpression.Parser.Select(x => (IRootExpression)new ClosedRootExpression(x)))
         .End();
 }

--- a/Expressif/Serializers/ParameterSerializer.cs
+++ b/Expressif/Serializers/ParameterSerializer.cs
@@ -19,6 +19,7 @@ public class ParameterSerializer
         return parameter switch
         {
             ArrayParameter a => $"{{{string.Join(", ", a.Values.Select(Serialize))}}}",
+            TupleParameter t => $"T({string.Join(", ", t.Values.Select(Serialize))})",
             RecordLiteralParameter r when r.Fields.Length == 0 => "{:}",
             RecordLiteralParameter r => $"{{{string.Join(", ", r.Fields.Select(x => $"{SerializeFieldName(x.Name)} := {Serialize(x.Value)}"))}}}",
             RecordDefinitionParameter definition => string.Join(", ", definition.Entries.Select(SerializeRecordEntry)),
@@ -34,6 +35,7 @@ public class ParameterSerializer
             VariableParameter v => $"@{v.Name}",
             ObjectPropertyParameter op => $"[{op.Name}]",
             ObjectIndexParameter oi => $"#{oi.Index}",
+            TupleProjectionParameter tp => $"${tp.Index}",
             _ => throw new NotSupportedException()
         };
     }

--- a/Expressif/Values/ContextObject.cs
+++ b/Expressif/Values/ContextObject.cs
@@ -25,6 +25,7 @@ public class ContextObject
         {
             DataRow row => index < row.Table.Columns.Count,
             ILiteDataRow row => index < row.ColumnCount,
+            TupleValue tuple => index >= 0 && index < tuple.Count,
             IList list => index < list.Count,
             _ => throw new NotIndexableContextObjectException(Value)
         };
@@ -37,6 +38,7 @@ public class ContextObject
             {
                 DataRow row => index < row.Table.Columns.Count ? row[index] : throw new ArgumentOutOfRangeException(index.ToString()),
                 ILiteDataRow row => index < row.ColumnCount ? row[index] : throw new ArgumentOutOfRangeException(index.ToString()),
+                TupleValue tuple => index >= 0 && index < tuple.Count ? tuple[index] : null,
                 IList list => list[index],
                 _ => throw new NotIndexableContextObjectException(Value)
             };

--- a/Expressif/Values/TupleValue.cs
+++ b/Expressif/Values/TupleValue.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Expressif.Values;
+
+/// <summary>
+/// Represents an immutable, ordered collection of two or more heterogeneous values.
+/// </summary>
+public class TupleValue : IReadOnlyList<object?>, IEquatable<TupleValue>
+{
+    private readonly object?[] values;
+
+    public TupleValue(params object?[] values)
+    {
+        ArgumentNullException.ThrowIfNull(values);
+        if (values.Length < 2)
+            throw new ArgumentException("A tuple must contain at least two values.", nameof(values));
+
+        this.values = [.. values];
+    }
+
+    public int Count => values.Length;
+    public object? this[int index] => values[index];
+
+    public IEnumerator<object?> GetEnumerator()
+        => ((IEnumerable<object?>)values).GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator()
+        => values.GetEnumerator();
+
+    public bool Equals(TupleValue? other)
+        => other is not null && values.SequenceEqual(other.values);
+
+    public override bool Equals(object? obj)
+        => obj is TupleValue other && Equals(other);
+
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        foreach (var value in values)
+            hash.Add(value);
+        return hash.ToHashCode();
+    }
+
+    public override string ToString()
+        => ValueFormatter.Format(this);
+}
+
+/// <summary>
+/// Represents the public canonical tuple value type.
+/// </summary>
+public sealed class Tuple : TupleValue
+{
+    public Tuple(params object?[] values) : base(values) { }
+}

--- a/Expressif/Values/ValueFormatter.cs
+++ b/Expressif/Values/ValueFormatter.cs
@@ -20,7 +20,10 @@ public static class ValueFormatter
         if (TryFormatNamedCollection(value!, out var named))
             return named;
 
-        return FormatScalarOrEnumerable(value, forRecordValue);
+        if (value is TupleValue tuple)
+            return $"T({string.Join(", ", tuple.Select(x => Format(x, forRecordValue)))})";
+
+        return FormatScalarOrEnumerable(value!, forRecordValue);
     }
 
     private static bool IsNullLike(object? value)

--- a/conformance/functions/array/adjacent.yaml
+++ b/conformance/functions/array/adjacent.yaml
@@ -1,0 +1,22 @@
+suite: array
+kind: function
+operator: adjacent
+tests:
+  - id: adjacent.valid.operation
+    cases:
+      - id: adjacent.valid.operation.special.null
+        value: (null)
+        expected:
+        parameters: [subtract]
+      - id: adjacent.valid.operation.special.empty
+        value: (empty)
+        expected:
+        parameters: [subtract]
+      - id: adjacent.valid.operation.array.empty
+        value: []
+        expected: []
+        parameters: [subtract]
+      - id: adjacent.valid.operation.array.values
+        value: [100, 105, 120]
+        expected: [5, 15]
+        parameters: [subtract]

--- a/conformance/functions/array/pairwise.yaml
+++ b/conformance/functions/array/pairwise.yaml
@@ -1,0 +1,18 @@
+suite: array
+kind: function
+operator: pairwise
+tests:
+  - id: pairwise.valid
+    cases:
+      - id: pairwise.valid.special.null
+        value: (null)
+        expected:
+      - id: pairwise.valid.special.empty
+        value: (empty)
+        expected:
+      - id: pairwise.valid.array.empty
+        value: []
+        expected: []
+      - id: pairwise.valid.array.values
+        value: [100, 105, 120]
+        expected: [[100, 105], [105, 120]]

--- a/conformance/functions/special/tuple-at.yaml
+++ b/conformance/functions/special/tuple-at.yaml
@@ -1,0 +1,22 @@
+suite: special
+kind: function
+operator: tuple-at
+tests:
+  - id: tuple-at.valid.position
+    cases:
+      - id: tuple-at.valid.position.special.null
+        value: (null)
+        expected:
+        parameters: [0]
+      - id: tuple-at.valid.position.special.empty
+        value: (empty)
+        expected:
+        parameters: [0]
+      - id: tuple-at.valid.position.tuple.first
+        value: T(10, 20)
+        expected: 10
+        parameters: [0]
+      - id: tuple-at.valid.position.tuple.out-of-range
+        value: T(10, 20)
+        expected:
+        parameters: [2]

--- a/conformance/functions/special/tuple-first.yaml
+++ b/conformance/functions/special/tuple-first.yaml
@@ -1,0 +1,18 @@
+suite: special
+kind: function
+operator: tuple-first
+tests:
+  - id: tuple-first.valid
+    cases:
+      - id: tuple-first.valid.special.null
+        value: (null)
+        expected:
+      - id: tuple-first.valid.special.empty
+        value: (empty)
+        expected:
+      - id: tuple-first.valid.tuple.numeric
+        value: T(10, 20)
+        expected: 10
+      - id: tuple-first.valid.tuple.text
+        value: T(one, two)
+        expected: one

--- a/conformance/functions/special/tuple-second.yaml
+++ b/conformance/functions/special/tuple-second.yaml
@@ -1,0 +1,18 @@
+suite: special
+kind: function
+operator: tuple-second
+tests:
+  - id: tuple-second.valid
+    cases:
+      - id: tuple-second.valid.special.null
+        value: (null)
+        expected:
+      - id: tuple-second.valid.special.empty
+        value: (empty)
+        expected:
+      - id: tuple-second.valid.tuple.numeric
+        value: T(10, 20)
+        expected: 20
+      - id: tuple-second.valid.tuple.text
+        value: T(one, two)
+        expected: two

--- a/docs/_data/function.json
+++ b/docs/_data/function.json
@@ -2378,5 +2378,67 @@
     "Scope": "Text",
     "Summary": "Returns the argument string without white-space characters.",
     "Parameters": []
+  },
+  {
+    "Name": "adjacent",
+    "IsPublic": true,
+    "Aliases": [
+      "adjacent"
+    ],
+    "Scope": "Array",
+    "Summary": "Evaluates an operation against every consecutive pair of input values. Returns `null` when the input cannot be evaluated.",
+    "Parameters": [
+      {
+        "Name": "operation",
+        "Optional": false,
+        "Summary": "Specifies the callable or open expression evaluated against each consecutive pair."
+      }
+    ]
+  },
+  {
+    "Name": "pairwise",
+    "IsPublic": true,
+    "Aliases": [
+      "pairwise"
+    ],
+    "Scope": "Array",
+    "Summary": "Returns each consecutive pair of input values as a tuple. Returns `null` when the input cannot be evaluated.",
+    "Parameters": []
+  },
+  {
+    "Name": "tuple-at",
+    "IsPublic": true,
+    "Aliases": [
+      "tuple-at"
+    ],
+    "Scope": "Special",
+    "Summary": "Returns the tuple field at the specified zero-based position. Returns `null` when the input is not a tuple or the position is out of range.",
+    "Parameters": [
+      {
+        "Name": "position",
+        "Optional": false,
+        "Summary": "Specifies the zero-based position of the tuple field to return."
+      }
+    ]
+  },
+  {
+    "Name": "tuple-first",
+    "IsPublic": true,
+    "Aliases": [
+      "tuple-first"
+    ],
+    "Scope": "Special",
+    "Summary": "Returns the first field of a tuple. Returns `null` when the input is not a tuple.",
+    "Parameters": []
+  },
+  {
+    "Name": "tuple-second",
+    "IsPublic": true,
+    "Aliases": [
+      "tuple-second"
+    ],
+    "Scope": "Special",
+    "Summary": "Returns the second field of a tuple. Returns `null` when the input is not a tuple.",
+    "Parameters": []
   }
 ]


### PR DESCRIPTION
Closes #488.
Closes #489.
Closes #490.

## What changed

- adds the immutable Tuple value type, `T(...)` parsing/serialization, positional `$n` projections, and `tuple-first`/`tuple-second`/`tuple-at`
- adds progressive `pairwise` traversal returning Tuples
- adds `adjacent` composition over `pairwise`, including binary function/predicate shorthand and lexically bound tuple projections
- adds scaffolded documentation metadata, conformance YAML, parser coverage, and focused behavior tests

## Validation

- `dotnet test Expressif.Testing/Expressif.Testing.csproj --no-restore -m:1 -p:UseSharedCompilation=false -f net8.0` (2,759 passed, 1 skipped)
- equivalent test runs passed on net9.0 and net10.0