### PR TITLE
feat(numeric): add percent-change numeric function

### DIFF
--- a/Expressif.Testing/Functions/Numeric/PercentChangeFunctionTest.cs
+++ b/Expressif.Testing/Functions/Numeric/PercentChangeFunctionTest.cs
@@ -1,0 +1,26 @@
+using Expressif.Functions;
+using Expressif.Functions.Numeric;
+using Expressif.Testing.Conformance;
+using Expressif.Values;
+using Expressif.Values.Casters;
+
+namespace Expressif.Testing.Functions.Numeric;
+
+[TestFixture]
+public class PercentChangeFunctionTest
+{
+    [Conformance]
+    public void PercentChange_Valid_Previous(object value, object previous, decimal? expected)
+        => Assert.That(
+            new PercentChange(() => new Caster().Cast<decimal>(previous)).Evaluate(value),
+            Is.EqualTo(expected));
+
+    [TestCase("105 | percent-change(100)", 5)]
+    [TestCase("80 | percent-change(100)", -20)]
+    [TestCase("100 | percent-change(0)", null)]
+    [TestCase("100 | percent-change(abc)", null)]
+    public void Instantiate_Expression_Valid(string expression, decimal? expected)
+        => Assert.That(
+            new ExpressionFactory().InstantiateClosed(expression, new Context()).Evaluate(null),
+            Is.EqualTo(expected));
+}

--- a/Expressif/Functions/Numeric/NumericFunctions.cs
+++ b/Expressif/Functions/Numeric/NumericFunctions.cs
@@ -21,7 +21,7 @@ public abstract class BaseNumericFunction : IFunction
         };
     }
 
-    private object? EvaluateUncasted(object value)
+    protected virtual object? EvaluateUncasted(object value)
     {
         if (new Null().Equals(value) || new Empty().Equals(value) || new Whitespace().Equals(value))
             return EvaluateNull();

--- a/Expressif/Functions/Numeric/PercentChangeFunction.cs
+++ b/Expressif/Functions/Numeric/PercentChangeFunction.cs
@@ -1,0 +1,44 @@
+using System;
+
+namespace Expressif.Functions.Numeric;
+
+/// <summary>
+/// Returns the percentage change from the previous numeric value to the current input value. Returns `null` when the input or parameter cannot be evaluated or when the previous value is zero.
+/// </summary>
+public class PercentChange : BaseNumericFunction
+{
+    public Func<decimal> Previous { get; }
+
+    /// <param name="previous">Specifies the previous numeric value used as the percentage-change baseline.</param>
+    public PercentChange(Func<decimal> previous)
+        => Previous = previous;
+
+    protected override object? EvaluateUncasted(object value)
+    {
+        try
+        {
+            return base.EvaluateUncasted(value);
+        }
+        catch (InvalidCastException)
+        {
+            return null;
+        }
+    }
+
+    protected override decimal? EvaluateNumeric(decimal current)
+    {
+        decimal previous;
+        try
+        {
+            previous = Previous.Invoke();
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+
+        return previous == 0
+            ? null
+            : ((current - previous) / previous) * 100;
+    }
+}

--- a/conformance/functions/numeric/percent-change.yaml
+++ b/conformance/functions/numeric/percent-change.yaml
@@ -1,0 +1,51 @@
+suite: numeric
+kind: function
+operator: percent-change
+tests:
+  - id: percent-change.valid.previous
+    cases:
+      - id: percent-change.valid.previous.numeric.increase
+        value: 105
+        expected: 5
+        parameters:
+          - 100
+      - id: percent-change.valid.previous.numeric.decrease
+        value: 80
+        expected: -20
+        parameters:
+          - 100
+      - id: percent-change.valid.previous.numeric.equal
+        value: 100
+        expected: 0
+        parameters:
+          - 100
+      - id: percent-change.valid.previous.numeric.current-zero
+        value: 0
+        expected: -100
+        parameters:
+          - 100
+      - id: percent-change.valid.previous.numeric.previous-zero
+        value: 100
+        expected:
+        parameters:
+          - 0
+      - id: percent-change.valid.previous.numeric.non-evaluable-input
+        value: abc
+        expected:
+        parameters:
+          - 100
+      - id: percent-change.valid.previous.numeric.non-evaluable-previous
+        value: 100
+        expected:
+        parameters:
+          - abc
+      - id: percent-change.valid.previous.special.null
+        value: (null)
+        expected:
+        parameters:
+          - 100
+      - id: percent-change.valid.previous.special.empty
+        value: (empty)
+        expected:
+        parameters:
+          - 100

--- a/docs/_data/function.json
+++ b/docs/_data/function.json
@@ -2440,5 +2440,21 @@
     "Scope": "Text",
     "Summary": "Returns the argument string without white-space characters.",
     "Parameters": []
+  },
+  {
+    "Name": "percent-change",
+    "IsPublic": true,
+    "Aliases": [
+      "percent-change"
+    ],
+    "Scope": "Numeric",
+    "Summary": "Returns the percentage change from the previous numeric value to the current input value. Returns `null` when the input or parameter cannot be evaluated or when the previous value is zero.",
+    "Parameters": [
+      {
+        "Name": "previous",
+        "Optional": false,
+        "Summary": "Specifies the previous numeric value used as the percentage-change baseline."
+      }
+    ]
   }
 ]


### PR DESCRIPTION
## Summary

- add the public Numeric `percent-change(previous)` function
- preserve explicit current/previous operand order and return `null` for zero baselines
- handle non-evaluable inputs and parameters gracefully
- register documentation metadata and add conformance plus parser coverage

## Why

Issue #486 requests a binary numeric percentage-change operation using `((current - previous) / previous) * 100`. Numeric input conversion happens in `BaseNumericFunction` before derived evaluation, so its conversion hook is now overridable; `PercentChange` contains conversion failures without changing behavior for existing numeric functions.

## Validation

- focused `PercentChangeFunctionTest`: 13 passed on .NET 8, .NET 9, and .NET 10
- full `Expressif.Testing` suite: 2,752 passed and 1 skipped on each of .NET 8, .NET 9, and .NET 10
- `git diff --check`

Closes #486

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `percent-change` numeric function to calculate percentage change from a previous value.
  * Handles increases, decreases, equal values, zero values, and invalid or unavailable inputs by returning an empty result where appropriate.
* **Documentation**
  * Added public reference documentation and conformance coverage for the new function.
* **Extensibility**
  * Improved numeric function customization for specialized value handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->