### PR TITLE
feat(cli): configure CSV source profiles

### DIFF
--- a/Expressif.Cli.Tests/CliCommandTests.cs
+++ b/Expressif.Cli.Tests/CliCommandTests.cs
@@ -642,6 +642,71 @@ public class CliCommandTests
     }
 
     [Test]
+    public async Task Run_SourceCsv_WithRepeatedSourceOptions_UsesConfiguredProfile()
+    {
+        var sourcePath = CreateTempFile($"name;country{Environment.NewLine} Alice;Belgium{Environment.NewLine} Bob;France", ".csv");
+
+        var result = await InvokeAsync(
+            "run", "[name] | upper", "--source", sourcePath,
+            "--source-option", "delimiter=\";\"",
+            "--source-option", "skip-initial-space=true");
+
+        var outputs = result.StdOut.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.Success));
+            Assert.That(outputs, Is.EqualTo(new[] { "ALICE", "BOB" }));
+            Assert.That(result.StdErr, Is.Empty);
+        });
+    }
+
+    [Test]
+    public async Task Run_SourceCsv_WithExplicitHeader_UsesPocketCsvHeaderNames()
+    {
+        var sourcePath = CreateTempFile($"name,country{Environment.NewLine}Alice,Belgium{Environment.NewLine}Bob,France", ".csv");
+
+        var result = await InvokeAsync(
+            "run", "[name] | upper", "--source", sourcePath,
+            "--source-option", "header=true");
+
+        var outputs = result.StdOut.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.Success));
+            Assert.That(outputs, Is.EqualTo(new[] { "ALICE", "BOB" }));
+            Assert.That(result.StdErr, Is.Empty);
+        });
+    }
+
+    [Test]
+    public async Task Run_SourceOption_WithoutSource_ReturnsClearError()
+    {
+        var result = await InvokeAsync("run", "absolute", "--input", "1", "--source-option", "header=true");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.InvalidExpressionOrInput));
+            Assert.That(result.StdOut, Is.Empty);
+            Assert.That(result.StdErr.Trim(), Is.EqualTo("The --source-option option requires --source."));
+        });
+    }
+
+    [Test]
+    public async Task Run_SourceCsv_InvalidSourceOption_ReturnsClearError()
+    {
+        var sourcePath = CreateTempFile("name,age", ".csv");
+
+        var result = await InvokeAsync("run", "[name]", "--source", sourcePath, "--source-option", "delimiter=\"long\"");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.InvalidExpressionOrInput));
+            Assert.That(result.StdOut, Is.Empty);
+            Assert.That(result.StdErr, Does.Contain("Invalid CSV source option 'delimiter' with value '\"long\"'"));
+        });
+    }
+
+    [Test]
     public async Task Run_SourceCsvHeaderOnly_ProducesNoOutputAndSuccess()
     {
         var sourcePath = CreateTempFile("name,age,country", ".csv");

--- a/Expressif.Cli.Tests/CsvSourceOptionTests.cs
+++ b/Expressif.Cli.Tests/CsvSourceOptionTests.cs
@@ -1,0 +1,53 @@
+using Expressif.Cli.Commands;
+
+namespace Expressif.Cli.Tests;
+
+public class CsvSourceOptionTests
+{
+    [Test]
+    public void BuildCsvProfile_AllSupportedOptions_AreTranslated()
+    {
+        var (profile, hasHeader) = RunCommand.BuildCsvProfile(
+        [
+            "delimiter=\";\"", "line-terminator=\"|\"", "quote-char=null",
+            "double-quote=false", "escape-char=\"\\\\\"", "header=false",
+            "header-rows={1, 3}", "header-join=\".\"", "header-repeat=false",
+            "comment-char=\"#\"", "comment-rows={2, 4}", "null-sequence=\"NULL\"",
+            "missing-cell=\"missing\"", "skip-initial-space=true",
+            "array-delimiter=\";\"", "array-prefix=\"[\"", "array-suffix=\"]\""
+        ]);
+
+        var dialect = profile.Dialect;
+        Assert.Multiple(() =>
+        {
+            Assert.That(dialect.Delimiter, Is.EqualTo(';'));
+            Assert.That(dialect.LineTerminator, Is.EqualTo("|"));
+            Assert.That(dialect.QuoteChar, Is.Null);
+            Assert.That(dialect.DoubleQuote, Is.False);
+            Assert.That(dialect.EscapeChar, Is.EqualTo('\\'));
+            Assert.That(dialect.Header, Is.False);
+            Assert.That(hasHeader, Is.False);
+            Assert.That(dialect.HeaderRows, Is.EqualTo(new[] { 1, 3 }));
+            Assert.That(dialect.HeaderJoin, Is.EqualTo("."));
+            Assert.That(dialect.HeaderRepeat, Is.False);
+            Assert.That(dialect.CommentChar, Is.EqualTo('#'));
+            Assert.That(dialect.CommentRows, Is.EqualTo(new[] { 2, 4 }));
+            Assert.That(dialect.NullSequence, Is.EqualTo("NULL"));
+            Assert.That(dialect.MissingCell, Is.EqualTo("missing"));
+            Assert.That(dialect.SkipInitialSpace, Is.True);
+            Assert.That(dialect.ArrayDelimiter, Is.EqualTo(';'));
+            Assert.That(dialect.ArrayPrefix, Is.EqualTo('['));
+            Assert.That(dialect.ArraySuffix, Is.EqualTo(']'));
+        });
+    }
+
+    [TestCase("unknown=1", "Unknown CSV source option 'unknown' with value '1'.")]
+    [TestCase("delimiter=\"long\"", "Invalid CSV source option 'delimiter' with value '\"long\"'")]
+    [TestCase("header=\"true\"", "Invalid CSV source option 'header' with value '\"true\"'")]
+    [TestCase("header-rows={0}", "Invalid CSV source option 'header-rows' with value '{0}'")]
+    public void BuildCsvProfile_InvalidOption_IdentifiesNameAndValue(string option, string expected)
+    {
+        var exception = Assert.Throws<FormatException>(() => RunCommand.BuildCsvProfile([option]));
+        Assert.That(exception!.Message, Does.StartWith(expected));
+    }
+}

--- a/Expressif.Cli/Commands/RunCommand.cs
+++ b/Expressif.Cli/Commands/RunCommand.cs
@@ -80,12 +80,18 @@ internal static class RunCommand
         };
         sourceOption.Aliases.Add("-s");
 
+        var sourceProfileOption = new Option<string[]>("--source-option")
+        {
+            Description = "Source-specific setting in <name>=<value> form. Repeat to add settings."
+        };
+
         var command = new Command("run", "Evaluate an Expressif expression for each element of an input sequence.");
 
         command.Arguments.Add(expressionArgument);
         command.Options.Add(inputOption);
         command.Options.Add(batchOption);
         command.Options.Add(sourceOption);
+        command.Options.Add(sourceProfileOption);
         command.Options.Add(expressionFileOption);
 
         command.SetAction(parseResult =>
@@ -93,11 +99,13 @@ internal static class RunCommand
             var inlineExpression = parseResult.GetValue(expressionArgument);
             var expressionFilePath = parseResult.GetValue(expressionFileOption);
             var sourcePath = parseResult.GetValue(sourceOption);
+            var sourceProfileOptions = parseResult.GetValue(sourceProfileOption) ?? [];
             var inputRows = parseResult.GetValue(inputOption) ?? [];
             var batchInput = parseResult.GetValue(batchOption);
             var hasInputOption = parseResult.GetResult(inputOption) is not null;
             var hasBatchOption = parseResult.GetResult(batchOption) is not null;
             var hasSourceOption = parseResult.GetResult(sourceOption) is not null;
+            var hasSourceProfileOption = parseResult.GetResult(sourceProfileOption) is not null;
 
             var batchOptionOccurrences = parseResult.Tokens.Count(token => token.Value is "--batch");
             if (batchOptionOccurrences > 1)
@@ -127,8 +135,14 @@ internal static class RunCommand
                 return ExitCodes.InvalidExpressionOrInput;
             }
 
+            if (hasSourceProfileOption && !hasSourceOption)
+            {
+                Console.Error.WriteLine("The --source-option option requires --source.");
+                return ExitCodes.InvalidExpressionOrInput;
+            }
+
             var sequenceInput = hasSourceOption
-                ? BuildSourceRows(sourcePath)
+                ? BuildSourceRows(sourcePath, sourceProfileOptions)
                 : BuildInputSequence(inputRows, hasBatchOption, batchInput);
 
             var context = new Context();
@@ -272,12 +286,15 @@ internal static class RunCommand
         }
     }
 
-    private static IEnumerable<object?> BuildSourceRows(string? sourcePath)
+    private static IEnumerable<object?> BuildSourceRows(string? sourcePath, IReadOnlyList<string> sourceOptions)
     {
         object? sourceValue;
         try
         {
-            sourceValue = ResolveSourceValue(sourcePath ?? string.Empty);
+            var path = sourcePath ?? string.Empty;
+            sourceValue = sourceOptions.Count == 0
+                ? ResolveSourceValue(path)
+                : ResolveSourceValueCore(path, sourceOptions);
         }
         catch (FormatException)
         {
@@ -450,6 +467,9 @@ internal static class RunCommand
     }
 
     private static object? ResolveSourceValueCore(string sourcePath)
+        => ResolveSourceValueCore(sourcePath, []);
+
+    private static object? ResolveSourceValueCore(string sourcePath, IReadOnlyList<string> sourceOptions)
     {
         if (string.IsNullOrWhiteSpace(sourcePath))
             throw new FormatException("Source path is required.");
@@ -460,8 +480,12 @@ internal static class RunCommand
         if (!File.Exists(sourcePath))
             throw new FormatException($"Source '{sourcePath}' was not found.");
 
-        if (Path.GetExtension(sourcePath).Equals(".csv", StringComparison.OrdinalIgnoreCase))
-            return OpenCsvDataReader(sourcePath);
+        var isCsv = Path.GetExtension(sourcePath).Equals(".csv", StringComparison.OrdinalIgnoreCase);
+        if (sourceOptions.Count > 0 && !isCsv)
+            throw new FormatException($"Source options are not supported for source '{sourcePath}'.");
+
+        if (isCsv)
+            return OpenCsvDataReader(sourcePath, sourceOptions);
 
         var sourceCode = ReadUtf8File(sourcePath);
         ClosedExpression closedExpression;
@@ -487,21 +511,161 @@ internal static class RunCommand
         }
     }
 
-    private static IDataReader OpenCsvDataReader(string sourcePath)
+    private static IDataReader OpenCsvDataReader(string sourcePath, IReadOnlyList<string> sourceOptions)
     {
         FileStream? stream = null;
         try
         {
             stream = new FileStream(sourcePath, FileMode.Open, FileAccess.Read, FileShare.Read);
-            var csvReader = new CsvReader(CsvProfile.CommaDoubleQuote);
+            var (profile, hasHeaderRecord) = BuildCsvProfile(sourceOptions);
+            // Expressif builds dynamic row records from the CSV header. PocketCsvReader's
+            // schema-driven header mode requires a named schema, so keep header rows visible
+            // to the row adapter while retaining the configured profile for validation.
+            var readerProfile = profile.Dialect.Header ? WithoutCsvHeaderConsumption(profile) : profile;
+            var csvReader = new CsvReader(readerProfile);
             var csvDataReader = csvReader.ToDataReader(stream);
-            return new DisposableDataReader(csvDataReader, stream, hasHeaderRecord: true);
+            return new DisposableDataReader(csvDataReader, stream, hasHeaderRecord);
         }
         catch
         {
             stream?.Dispose();
             throw;
         }
+    }
+
+    internal static (CsvProfile Profile, bool HasHeaderRecord) BuildCsvProfile(IReadOnlyList<string> options)
+    {
+        var baseline = CsvProfile.CommaDoubleQuote;
+        var defaults = baseline.Dialect;
+        var header = defaults.Header;
+        var headerRows = defaults.HeaderRows;
+        var headerJoin = defaults.HeaderJoin;
+        var headerRepeat = defaults.HeaderRepeat;
+        var commentRows = defaults.CommentRows;
+        var commentChar = defaults.CommentChar;
+        var delimiter = defaults.Delimiter;
+        var lineTerminator = defaults.LineTerminator;
+        var quoteChar = defaults.QuoteChar;
+        var doubleQuote = defaults.DoubleQuote;
+        var escapeChar = defaults.EscapeChar;
+        var nullSequence = defaults.NullSequence;
+        var missingCell = defaults.MissingCell;
+        var skipInitialSpace = defaults.SkipInitialSpace;
+        var arrayDelimiter = defaults.ArrayDelimiter;
+        var arrayPrefix = defaults.ArrayPrefix;
+        var arraySuffix = defaults.ArraySuffix;
+        var hasHeaderRecord = true;
+
+        foreach (var option in options)
+        {
+            var separator = option.IndexOf('=');
+            if (separator <= 0)
+                throw new FormatException($"Invalid source option '{option}'. Expected <name>=<value>.");
+
+            var name = option[..separator].Trim();
+            var suppliedValue = option[(separator + 1)..];
+            object? value;
+            try
+            {
+                value = InputValueParser.ParseSourceOptionValue(suppliedValue);
+            }
+            catch (FormatException exception)
+            {
+                throw InvalidSourceOption(name, suppliedValue, exception.Message);
+            }
+
+            try
+            {
+                switch (name)
+                {
+                    case "delimiter": delimiter = RequiredChar(value, name); break;
+                    case "line-terminator": lineTerminator = RequiredText(value, name); break;
+                    case "quote-char": quoteChar = OptionalChar(value, name); break;
+                    case "double-quote": doubleQuote = RequiredBoolean(value, name); break;
+                    case "escape-char": escapeChar = OptionalChar(value, name); break;
+                    case "header": header = hasHeaderRecord = RequiredBoolean(value, name); break;
+                    case "header-rows": headerRows = RequiredRows(value, name); break;
+                    case "header-join": headerJoin = RequiredText(value, name); break;
+                    case "header-repeat": headerRepeat = RequiredBoolean(value, name); break;
+                    case "comment-char": commentChar = OptionalChar(value, name); break;
+                    case "comment-rows": commentRows = RequiredRows(value, name); break;
+                    case "null-sequence": nullSequence = RequiredText(value, name); break;
+                    case "missing-cell": missingCell = RequiredText(value, name); break;
+                    case "skip-initial-space": skipInitialSpace = RequiredBoolean(value, name); break;
+                    case "array-delimiter": arrayDelimiter = OptionalChar(value, name); break;
+                    case "array-prefix": arrayPrefix = OptionalChar(value, name); break;
+                    case "array-suffix": arraySuffix = OptionalChar(value, name); break;
+                    default: throw new FormatException($"Unknown CSV source option '{name}' with value '{suppliedValue}'.");
+                }
+            }
+            catch (FormatException exception) when (!exception.Message.Contains("with value", StringComparison.Ordinal))
+            {
+                throw InvalidSourceOption(name, suppliedValue, exception.Message);
+            }
+        }
+
+        CsvProfile profile;
+        try
+        {
+            var dialect = new DialectDescriptor(
+                header, headerRows, headerJoin, headerRepeat, commentRows, commentChar,
+                delimiter, lineTerminator, quoteChar, doubleQuote, escapeChar, nullSequence,
+                missingCell, skipInitialSpace, arrayDelimiter, arrayPrefix, arraySuffix);
+            profile = new CsvProfile(dialect, baseline.Schema, baseline.Resource, baseline.Parsers);
+        }
+        catch (Exception exception) when (exception is not OutOfMemoryException)
+        {
+            throw new FormatException($"Invalid CSV source-option combination: {exception.Message}", exception);
+        }
+
+        return (profile, hasHeaderRecord);
+    }
+
+    private static CsvProfile WithoutCsvHeaderConsumption(CsvProfile profile)
+    {
+        var dialect = profile.Dialect;
+        var readerDialect = new DialectDescriptor(
+            false, [], dialect.HeaderJoin, dialect.HeaderRepeat, dialect.CommentRows, dialect.CommentChar,
+            dialect.Delimiter, dialect.LineTerminator, dialect.QuoteChar, dialect.DoubleQuote,
+            dialect.EscapeChar, dialect.NullSequence, dialect.MissingCell, dialect.SkipInitialSpace,
+            dialect.ArrayDelimiter, dialect.ArrayPrefix, dialect.ArraySuffix);
+        return new CsvProfile(readerDialect, profile.Schema, profile.Resource, profile.Parsers);
+    }
+
+    private static FormatException InvalidSourceOption(string name, string value, string reason)
+        => new($"Invalid CSV source option '{name}' with value '{value}': {reason}");
+
+    private static bool RequiredBoolean(object? value, string name)
+        => value is bool result ? result : throw new FormatException($"'{name}' requires a boolean.");
+
+    private static string RequiredText(object? value, string name)
+        => value is string result ? result : throw new FormatException($"'{name}' requires text.");
+
+    private static char RequiredChar(object? value, string name)
+        => OptionalChar(value, name) ?? throw new FormatException($"'{name}' cannot be null.");
+
+    private static char? OptionalChar(object? value, string name)
+    {
+        if (value is null)
+            return null;
+        if (value is string { Length: 1 } text)
+            return text[0];
+        throw new FormatException($"'{name}' requires a single character or null.");
+    }
+
+    private static int[] RequiredRows(object? value, string name)
+    {
+        if (value is not object?[] values || values.Length == 0)
+            throw new FormatException($"'{name}' requires a non-empty array of one-based row indexes.");
+
+        var rows = new int[values.Length];
+        for (var i = 0; i < values.Length; i++)
+        {
+            if (values[i] is not int row || row < 1)
+                throw new FormatException($"'{name}' requires a non-empty array of one-based row indexes.");
+            rows[i] = row;
+        }
+        return rows;
     }
 
     private static string ReadUtf8File(string sourcePath)
@@ -550,6 +714,30 @@ internal static class RunCommand
                 if (TryParseAutoQuotedScalar(text, out var autoQuotedValue))
                     return autoQuotedValue;
 
+                throw new FormatException(exception.Message, exception);
+            }
+        }
+
+        public static object? ParseSourceOptionValue(string text)
+        {
+            var normalized = text.Trim();
+            try
+            {
+                var parameter = Parameter.Parser.End().Parse(text);
+                if (normalized.Length >= 2 && normalized[0] is '"' or '`')
+                {
+                    return parameter switch
+                    {
+                        LiteralParameter literal => literal.Value,
+                        QuotedLiteralParameter quoted => quoted.Value,
+                        _ => ConvertToRuntimeValue(parameter)
+                    };
+                }
+
+                return ConvertToRuntimeValue(parameter);
+            }
+            catch (ParseException exception)
+            {
                 throw new FormatException(exception.Message, exception);
             }
         }

--- a/docs/_docs/using-expressif-cli.md
+++ b/docs/_docs/using-expressif-cli.md
@@ -187,6 +187,39 @@ For CSV input:
 - malformed rows (wrong field count) fail with a clear error;
 - processing is streamed row by row so large files can be processed efficiently.
 
+CSV parsing can be configured by repeating `--source-option <name>=<value>`. Options apply only to the file supplied by `--source`.
+
+```console
+expressif run "[name] | upper" --source people.csv \
+  --source-option 'delimiter=";"' \
+  --source-option 'header=true' \
+  --source-option 'quote-char="\""'
+```
+
+Supported CSV source options are:
+
+| Option | Value |
+| --- | --- |
+| `delimiter` | Single field-separator character |
+| `line-terminator` | Record-separator text |
+| `quote-char` | Single character, or `null` to disable quoting |
+| `double-quote` | Boolean controlling doubled-quote escaping |
+| `escape-char` | Single character, or `null` to disable explicit escaping |
+| `header` | Boolean indicating whether header rows are present |
+| `header-rows` | Array of one-based physical row indexes, such as `{1, 2}` |
+| `header-join` | Text joining values from multiple header rows |
+| `header-repeat` | Boolean controlling repeated empty header cells |
+| `comment-char` | Single character identifying comment rows, or `null` |
+| `comment-rows` | Array of one-based physical row indexes to ignore |
+| `null-sequence` | Text interpreted as null |
+| `missing-cell` | Text used for a missing trailing cell |
+| `skip-initial-space` | Boolean controlling whitespace after delimiters |
+| `array-delimiter` | Single embedded-array separator character, or `null` |
+| `array-prefix` | Single embedded-array opening character, or `null` |
+| `array-suffix` | Single embedded-array closing character, or `null` |
+
+Values use Expressif literal syntax: `true` and `false` for booleans, `null`, quoted text, and arrays such as `{1, 3}`. Unknown properties, invalid values, and incompatible profiles are rejected. CSV behavior is unchanged when no source options are supplied.
+
 For non-CSV source files, the source expression is evaluated first and must return an enumerable sequence.
 
 Examples:


### PR DESCRIPTION
## Summary

- add repeatable `--source-option <name>=<value>` arguments to `expressif run`
- validate and translate all supported CSV settings into PocketCsvReader profile descriptors
- preserve existing CSV behavior when no source options are provided
- document the supported properties and add profile/unit plus CLI integration coverage

Closes #481.

## User impact

CSV sources can now configure delimiters, quoting and escaping, headers, comments, null and missing cells, whitespace handling, and embedded arrays without adding CSV-specific top-level CLI flags. Invalid names and values identify the supplied property and value.

## Validation

- Focused #481 suite: 9 passed
- Full `Expressif.Cli.Tests` suite: 79 passed, 1 unrelated existing expectation failed (`Run_InputRecordWithDuplicateFields_ReturnsClearError`; current `main` prepends `Input enumeration failed at position 0` to the expected message)
- `git diff --check`: clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added repeatable `--source-option name=value` support for configuring CSV input.
  * Added options for delimiters, quoting, headers, comments, whitespace, missing values, arrays, and related CSV parsing behavior.
  * Added support for typed and quoted option values.

* **Bug Fixes**
  * Added clear validation errors for invalid options, unsupported sources, and missing source configuration.

* **Documentation**
  * Documented CSV source options, supported values, validation, and default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->