### PR TITLE
feat(accumulator): add every and any

### DIFF
--- a/Expressif.Testing/Accumulators/Introspection/AccumulatorIntrospectorTest.cs
+++ b/Expressif.Testing/Accumulators/Introspection/AccumulatorIntrospectorTest.cs
@@ -77,6 +77,8 @@ public class AccumulatorIntrospectorTest
             Assert.That(Infos.Any(x => x.Name == "max"), Is.True);
             Assert.That(Infos.Any(x => x.Name == "first"), Is.True);
             Assert.That(Infos.Any(x => x.Name == "last"), Is.True);
+            Assert.That(Infos.Any(x => x.Name == "every"), Is.True);
+            Assert.That(Infos.Any(x => x.Name == "any"), Is.True);
         }
     }
 }

--- a/Expressif.Testing/ExpressionTest.cs
+++ b/Expressif.Testing/ExpressionTest.cs
@@ -266,6 +266,15 @@ public class ExpressionTest
         Assert.That(result, Is.EqualTo(6m));
     }
 
+    [TestCase("{true,true,true} | every", true)]
+    [TestCase("{true,false,true} | every", false)]
+    [TestCase("{false,true,false} | any", true)]
+    [TestCase("{false,false,false} | any", false)]
+    [TestCase("{} | every", true)]
+    [TestCase("{} | any", false)]
+    public void Evaluate_DirectBooleanAccumulatorSyntax_Valid(string code, bool expected)
+        => Assert.That(new ClosedExpression(code).Evaluate(), Is.EqualTo(expected));
+
     [Test]
     public void Evaluate_ArrayPipeMapMultiply_Valid()
     {

--- a/Expressif.Testing/Functions/Array/BroadcastTest.cs
+++ b/Expressif.Testing/Functions/Array/BroadcastTest.cs
@@ -31,6 +31,14 @@ public class BroadcastTest
         => Assert.That(new Broadcast(() => new LastAccumulator()).Evaluate(new object[] { 3, 2, 1 }), Is.EqualTo(Enumerable.Repeat(1, 3)));
 
     [Test]
+    public void Evaluate_EveryAccumulator_Valid()
+        => Assert.That(new Broadcast(() => new EveryAccumulator()).Evaluate(new object[] { true, true, false }), Is.EqualTo(Enumerable.Repeat(false, 3)));
+
+    [Test]
+    public void Evaluate_AnyAccumulator_Valid()
+        => Assert.That(new Broadcast(() => new AnyAccumulator()).Evaluate(new object[] { false, true, false }), Is.EqualTo(Enumerable.Repeat(true, 3)));
+
+    [Test]
     public void Evaluate_EmptyArray_ExpectedDefaults()
     {
         Assert.Multiple(() =>

--- a/Expressif.Testing/Functions/Array/FoldTest.cs
+++ b/Expressif.Testing/Functions/Array/FoldTest.cs
@@ -29,6 +29,18 @@ public class FoldTest
     public void Evaluate_LastAccumulator_Valid()
         => Assert.That(new Fold(() => new LastAccumulator()).Evaluate(new object[] { 3, 2, 1 }), Is.EqualTo(1));
 
+    [TestCaseSource(nameof(BooleanAccumulatorCases))]
+    public void Evaluate_BooleanAccumulator_Valid(IAccumulator accumulator, object[] input, bool expected)
+        => Assert.That(new Fold(() => accumulator).Evaluate(input), Is.EqualTo(expected));
+
+    private static readonly object[] BooleanAccumulatorCases =
+    [
+        new object[] { new EveryAccumulator(), new object[] { true, true, true }, true },
+        new object[] { new EveryAccumulator(), new object[] { true, false, true }, false },
+        new object[] { new AnyAccumulator(), new object[] { false, true, false }, true },
+        new object[] { new AnyAccumulator(), new object[] { false, false, false }, false }
+    ];
+
     [Test]
     public void Evaluate_EmptyArray_ExpectedDefaults()
     {
@@ -40,8 +52,20 @@ public class FoldTest
             Assert.That(new Fold(() => new MaxAccumulator()).Evaluate(System.Array.Empty<object>()), Is.Null);
             Assert.That(new Fold(() => new FirstAccumulator()).Evaluate(System.Array.Empty<object>()), Is.Null);
             Assert.That(new Fold(() => new LastAccumulator()).Evaluate(System.Array.Empty<object>()), Is.Null);
+            Assert.That(new Fold(() => new EveryAccumulator()).Evaluate(System.Array.Empty<object>()), Is.True);
+            Assert.That(new Fold(() => new AnyAccumulator()).Evaluate(System.Array.Empty<object>()), Is.False);
         });
     }
+
+    [TestCaseSource(nameof(BooleanAccumulators))]
+    public void Evaluate_BooleanAccumulatorWithNull_ThrowsInvalidCastException(IAccumulator accumulator)
+        => Assert.Throws<InvalidCastException>(() => new Fold(() => accumulator).Evaluate(new object?[] { null }));
+
+    [TestCaseSource(nameof(BooleanAccumulators))]
+    public void Evaluate_BooleanAccumulatorWithInvalidValue_ThrowsInvalidCastException(IAccumulator accumulator)
+        => Assert.Throws<InvalidCastException>(() => new Fold(() => accumulator).Evaluate(new object[] { "not-a-boolean" }));
+
+    private static readonly IAccumulator[] BooleanAccumulators = [new EveryAccumulator(), new AnyAccumulator()];
 
     [Test]
     public void Evaluate_NonEnumerableInput_Null()

--- a/Expressif.Testing/Functions/Array/ScanTest.cs
+++ b/Expressif.Testing/Functions/Array/ScanTest.cs
@@ -10,6 +10,14 @@ public class ScanTest
         => Assert.That(new Scan(() => new SumAccumulator()).Evaluate(new object[] { 1, 2, 3 }), Is.EqualTo(new object?[] { 1m, 3m, 6m }));
 
     [Test]
+    public void Evaluate_EveryAccumulator_Valid()
+        => Assert.That(new Scan(() => new EveryAccumulator()).Evaluate(new object[] { true, true, false, true }), Is.EqualTo(new object[] { true, true, false, false }));
+
+    [Test]
+    public void Evaluate_AnyAccumulator_Valid()
+        => Assert.That(new Scan(() => new AnyAccumulator()).Evaluate(new object[] { false, false, true, false }), Is.EqualTo(new object[] { false, false, true, true }));
+
+    [Test]
     public void Evaluate_OutputCardinalityEqualsInputCardinality()
     {
         var input = new object[] { 1, "2", true, 4m };

--- a/Expressif.Testing/Parsers/ExpressionTest.cs
+++ b/Expressif.Testing/Parsers/ExpressionTest.cs
@@ -30,6 +30,8 @@ public class ExpressionTest
     [TestCase("@foo | count")]
     [TestCase("[foo] | min")]
     [TestCase("#1 | last")]
+    [TestCase("{true,true} | every")]
+    [TestCase("{false,true} | any")]
     public void Parse_InputExpression_ImplicitFoldAggregation_Valid(string value)
         => Assert.That(Expressif.Parsers.ClosedExpression.Parser.Parse(value).IsImplicitFoldAggregation, Is.True);
 

--- a/Expressif/Accumulators/Accumulators.cs
+++ b/Expressif/Accumulators/Accumulators.cs
@@ -152,3 +152,49 @@ public class LastAccumulator : BaseAccumulator
     public override object? GetValue()
         => hasValue ? last : null;
 }
+
+/// <summary>
+/// Returns <see langword="true"/> only when every accumulated boolean value is <see langword="true"/>.
+/// </summary>
+/// <remarks>
+/// The neutral value is <see langword="true"/>. Each item is converted using <see cref="BooleanCaster"/>.
+/// A <see cref="InvalidCastException"/> is thrown when a <see langword="null"/> value is accumulated.
+/// </remarks>
+[Accumulator(prefix: "", aliases: ["every"])]
+public class EveryAccumulator : BaseAccumulator
+{
+    private bool every;
+    private BooleanCaster Caster { get; } = new();
+
+    public override void Initialize()
+        => every = true;
+
+    public override void Accumulate(object? item)
+        => every &= Caster.Cast(item ?? throw new InvalidCastException("Cannot cast null value to boolean for every aggregation."));
+
+    public override object GetValue()
+        => every;
+}
+
+/// <summary>
+/// Returns <see langword="true"/> when at least one accumulated boolean value is <see langword="true"/>.
+/// </summary>
+/// <remarks>
+/// The neutral value is <see langword="false"/>. Each item is converted using <see cref="BooleanCaster"/>.
+/// A <see cref="InvalidCastException"/> is thrown when a <see langword="null"/> value is accumulated.
+/// </remarks>
+[Accumulator(prefix: "", aliases: ["any"])]
+public class AnyAccumulator : BaseAccumulator
+{
+    private bool any;
+    private BooleanCaster Caster { get; } = new();
+
+    public override void Initialize()
+        => any = false;
+
+    public override void Accumulate(object? item)
+        => any |= Caster.Cast(item ?? throw new InvalidCastException("Cannot cast null value to boolean for any aggregation."));
+
+    public override object GetValue()
+        => any;
+}

--- a/Expressif/Parsers/Expression.cs
+++ b/Expressif/Parsers/Expression.cs
@@ -41,7 +41,9 @@ public class ClosedExpression : IExpression
         "min",
         "max",
         "first",
-        "last"
+        "last",
+        "every",
+        "any"
     ];
 
     public IEnumerable<Function> Members { get; }

--- a/conformance/accumulators/array/any.yaml
+++ b/conformance/accumulators/array/any.yaml
@@ -1,0 +1,18 @@
+suite: array
+kind: accumulator
+operator: any
+tests:
+  - id: any.valid
+    cases:
+      - id: any.valid.array.contains-true
+        value: "{false, true, false}"
+        expected: true
+      - id: any.valid.array.all-false
+        value: "{false, false, false}"
+        expected: false
+      - id: any.valid.special.empty
+        value: (empty)
+        expected: false
+      - id: any.valid.special.null
+        value: (null)
+        expected:

--- a/conformance/accumulators/array/every.yaml
+++ b/conformance/accumulators/array/every.yaml
@@ -1,0 +1,18 @@
+suite: array
+kind: accumulator
+operator: every
+tests:
+  - id: every.valid
+    cases:
+      - id: every.valid.array.all-true
+        value: "{true, true, true}"
+        expected: true
+      - id: every.valid.array.contains-false
+        value: "{true, false, true}"
+        expected: false
+      - id: every.valid.special.empty
+        value: (empty)
+        expected: true
+      - id: every.valid.special.null
+        value: (null)
+        expected:

--- a/docs/_data/accumulator.json
+++ b/docs/_data/accumulator.json
@@ -58,5 +58,25 @@
     "Scope": "Array",
     "Summary": "Computes the sum of all accumulated numeric values.",
     "Parameters": []
+  },
+  {
+    "Name": "every",
+    "IsPublic": true,
+    "Aliases": [
+      "every"
+    ],
+    "Scope": "Array",
+    "Summary": "Returns `true` only when every accumulated boolean value is `true`. Returns `null` when an input cannot be evaluated.",
+    "Parameters": []
+  },
+  {
+    "Name": "any",
+    "IsPublic": true,
+    "Aliases": [
+      "any"
+    ],
+    "Scope": "Array",
+    "Summary": "Returns `true` when at least one accumulated boolean value is `true`. Returns `null` when an input cannot be evaluated.",
+    "Parameters": []
   }
 ]

--- a/docs/_data/accumulator.json
+++ b/docs/_data/accumulator.json
@@ -1,5 +1,15 @@
 [
   {
+    "Name": "any",
+    "IsPublic": true,
+    "Aliases": [
+      "any"
+    ],
+    "Scope": "Array",
+    "Summary": "Returns `true` when at least one accumulated boolean value is `true`.",
+    "Parameters": []
+  },
+  {
     "Name": "count",
     "IsPublic": true,
     "Aliases": [
@@ -7,6 +17,16 @@
     ],
     "Scope": "Array",
     "Summary": "Counts the number of accumulated items, including `null` values.",
+    "Parameters": []
+  },
+  {
+    "Name": "every",
+    "IsPublic": true,
+    "Aliases": [
+      "every"
+    ],
+    "Scope": "Array",
+    "Summary": "Returns `true` only when every accumulated boolean value is `true`.",
     "Parameters": []
   },
   {
@@ -57,26 +77,6 @@
     ],
     "Scope": "Array",
     "Summary": "Computes the sum of all accumulated numeric values.",
-    "Parameters": []
-  },
-  {
-    "Name": "every",
-    "IsPublic": true,
-    "Aliases": [
-      "every"
-    ],
-    "Scope": "Array",
-    "Summary": "Returns `true` only when every accumulated boolean value is `true`. Returns `null` when an input cannot be evaluated.",
-    "Parameters": []
-  },
-  {
-    "Name": "any",
-    "IsPublic": true,
-    "Aliases": [
-      "any"
-    ],
-    "Scope": "Array",
-    "Summary": "Returns `true` when at least one accumulated boolean value is `true`. Returns `null` when an input cannot be evaluated.",
     "Parameters": []
   }
 ]

--- a/docs/_docs/array-accumulators.md
+++ b/docs/_docs/array-accumulators.md
@@ -2,9 +2,20 @@
 title: Array accumulators
 subtitle: Accumulators applicable to arrays
 tags: [accumulators, array]
-keywords: [count, first, last, max, min, sum] # AUTO-GENERATED KEYWORDS
+keywords: [any, count, every, first, last, max, min, sum] # AUTO-GENERATED KEYWORDS
 ---
+
+`every` and `any` accumulate boolean values directly and take no predicate parameter. They are distinct from the `all(...)` and `none(...)` array predicates, which evaluate a supplied predicate against array elements.
+
 <!-- START AUTO-GENERATED -->
+##### any
+
+###### Alias: `any`
+
+###### Overview
+
+Returns `true` when at least one accumulated boolean value is `true`. Returns `null` when an input cannot be evaluated.
+
 ##### count
 
 ###### Alias: `count`
@@ -12,6 +23,14 @@ keywords: [count, first, last, max, min, sum] # AUTO-GENERATED KEYWORDS
 ###### Overview
 
 Counts the number of accumulated items, including `null` values.
+
+##### every
+
+###### Alias: `every`
+
+###### Overview
+
+Returns `true` only when every accumulated boolean value is `true`. Returns `null` when an input cannot be evaluated.
 
 ##### first
 

--- a/docs/_docs/array-accumulators.md
+++ b/docs/_docs/array-accumulators.md
@@ -14,7 +14,7 @@ keywords: [any, count, every, first, last, max, min, sum] # AUTO-GENERATED KEYWO
 
 ###### Overview
 
-Returns `true` when at least one accumulated boolean value is `true`. Returns `null` when an input cannot be evaluated.
+Returns `true` when at least one accumulated boolean value is `true`.
 
 ##### count
 
@@ -30,7 +30,7 @@ Counts the number of accumulated items, including `null` values.
 
 ###### Overview
 
-Returns `true` only when every accumulated boolean value is `true`. Returns `null` when an input cannot be evaluated.
+Returns `true` only when every accumulated boolean value is `true`.
 
 ##### first
 


### PR DESCRIPTION
## Summary

- add `every` and `any` boolean accumulators with strict boolean casting
- support implicit fold syntax and the existing `fold`, `scan`, and `broadcast` lifecycle
- add neutral-value, progressive, broadcast, null, invalid-value, discovery, parser, and end-to-end tests
- scaffold conformance cases and regenerate accumulator documentation

## Behavior

- `every` starts at `true` and remains true only while all accumulated values cast to true
- `any` starts at `false` and becomes true when an accumulated value casts to true
- null and invalid accumulated values raise the same strict casting error used by typed accumulators

## Predicate naming cleanup

The requested base is `origin/main` at `f782418`. That commit removed the previously merged array quantifier implementation and its documentation, so this base contains no `every` alias on `all` and no `any` alias on `none` to remove. This PR does not restore or otherwise alter those predicates.

## Validation

- focused net10 suite: 130 passed
- full net10 suite: 2,799 passed, 1 skipped, 0 failed
- `git diff --check`

Closes #500


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `every` and `any` boolean array accumulators.
  * Supports direct expressions, broadcasting, scanning, folding, and implicit aggregation.
  * Handles empty arrays and invalid or null values consistently.

* **Documentation**
  * Added reference documentation and metadata describing both accumulators, including their behavior and supported usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->