### PR TITLE
feat(array): add chunk array function

### DIFF
--- a/Expressif.Testing/Functions/Array/ChunkTest.cs
+++ b/Expressif.Testing/Functions/Array/ChunkTest.cs
@@ -1,0 +1,36 @@
+using Expressif.Functions.Array;
+using Expressif.Testing.Conformance;
+
+namespace Expressif.Testing.Functions.Array;
+
+[TestFixture]
+public class ChunkTest
+{
+    [Conformance]
+    public void Chunk_Valid_Size(object input, int size, object? expected)
+        => Assert.That(new Chunk(() => size).Evaluate(input), Is.EqualTo(expected));
+
+    [TestCase(0)]
+    [TestCase(-1)]
+    public void Evaluate_InvalidSize_ReturnsNull(int size)
+        => Assert.That(new Chunk(() => size).Evaluate(new[] { 1, 2, 3 }), Is.Null);
+
+    [Test]
+    public void Expression_LiteralSize_InstantiatesAndEvaluates()
+        => Assert.That(new Expression("chunk(2)").Evaluate(new[] { 1, 2, 3 }),
+            Is.EqualTo(new object?[][] { [1, 2], [3] }));
+
+    [Test]
+    public void Expression_ParameterExpression_EvaluatesSizeFromContext()
+    {
+        var context = new Context();
+        context.Variables.Add<int>("size", 1);
+
+        Assert.That(new Expression("chunk({@size | increment})", context).Evaluate(new[] { 1, 2, 3 }),
+            Is.EqualTo(new object?[][] { [1, 2], [3] }));
+    }
+
+    [Test]
+    public void Evaluate_NonEnumerable_ReturnsNull()
+        => Assert.That(new Chunk(() => 2).Evaluate(42), Is.Null);
+}

--- a/Expressif/Functions/Array/Chunk.cs
+++ b/Expressif/Functions/Array/Chunk.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Expressif.Functions.Array;
+
+/// <summary>
+/// Splits an array into consecutive, non-overlapping chunks of at most the specified size, preserving a final partial chunk. It resembles a count-based tumbling window but, unlike general sliding or hopping windows, has no separate step and always keeps the final partial chunk. It does not group items by inactivity or time. Returns `null` when the input cannot be evaluated.
+/// </summary>
+[Function(prefix: "", aliases: ["chunk"])]
+public class Chunk : BaseArrayFunction
+{
+    public Func<int> Size { get; }
+
+    /// <param name="size">The strictly positive number of items in each chunk.</param>
+    public Chunk(Func<int> size)
+        => Size = size;
+
+    protected override object? EvaluateArray(IEnumerable enumerable)
+    {
+        var size = Size.Invoke();
+        if (size <= 0)
+            return null;
+
+        var chunks = new List<object?[]>();
+        var chunk = new List<object?>(size);
+        foreach (var item in enumerable)
+        {
+            chunk.Add(item);
+            if (chunk.Count != size)
+                continue;
+
+            chunks.Add(chunk.ToArray());
+            chunk = new List<object?>(size);
+        }
+
+        if (chunk.Count > 0)
+            chunks.Add(chunk.ToArray());
+
+        return chunks.ToArray();
+    }
+}

--- a/conformance/functions/array/chunk.yaml
+++ b/conformance/functions/array/chunk.yaml
@@ -1,0 +1,41 @@
+suite: array
+kind: function
+operator: chunk
+tests:
+  - id: chunk.valid.size
+    cases:
+      - id: chunk.valid.size.numeric.partial
+        value: [1, 2, 3, 4, 5]
+        expected: [[1, 2], [3, 4], [5]]
+        parameters:
+          - 2
+      - id: chunk.valid.size.numeric.exact
+        value: [1, 2, 3, 4]
+        expected: [[1, 2], [3, 4]]
+        parameters:
+          - 2
+      - id: chunk.valid.size.numeric.larger-than-input
+        value: [1, 2, 3]
+        expected: [[1, 2, 3]]
+        parameters:
+          - 10
+      - id: chunk.valid.size.numeric.singleton
+        value: [1, 2, 3]
+        expected: [[1], [2], [3]]
+        parameters:
+          - 1
+      - id: chunk.valid.size.special.empty-array
+        value: []
+        expected: []
+        parameters:
+          - 2
+      - id: chunk.valid.size.special.null
+        value: (null)
+        expected:
+        parameters:
+          - 2
+      - id: chunk.valid.size.special.empty
+        value: (empty)
+        expected:
+        parameters:
+          - 2

--- a/docs/_data/function.json
+++ b/docs/_data/function.json
@@ -2448,6 +2448,22 @@
     "Parameters": []
   },
   {
+    "Name": "chunk",
+    "IsPublic": true,
+    "Aliases": [
+      "chunk"
+    ],
+    "Scope": "Array",
+    "Summary": "Splits an array into consecutive, non-overlapping chunks of at most the specified size, preserving a final partial chunk. It resembles a count-based tumbling window but, unlike general sliding or hopping windows, has no separate step and always keeps the final partial chunk. It does not group items by inactivity or time. Returns `null` when the input cannot be evaluated.",
+    "Parameters": [
+      {
+        "Name": "size",
+        "Optional": false,
+        "Summary": "The strictly positive number of items in each chunk."
+      }
+    ]
+  },
+  {
     "Name": "without-whitespaces",
     "IsPublic": true,
     "Aliases": [


### PR DESCRIPTION
## Summary

- add the public `chunk(size)` array function
- preserve input order and final partial chunks while rejecting non-positive sizes
- register the function through existing introspection-based parser/factory discovery
- add documentation metadata, conformance coverage, and focused unit tests

## Why

Closes #502 by providing a simple count-based array partitioning operation. It is documented as similar to a tumbling window while remaining distinct from sliding, hopping, session, and time windows.

## Validation

- `dotnet test Expressif.Testing/Expressif.Testing.csproj --nologo --no-restore --disable-build-servers -m:1`
- .NET 8: 2,791 passed, 1 skipped
- .NET 9: 2,791 passed, 1 skipped
- .NET 10: 2,791 passed, 1 skipped

The skipped serializer test was pre-existing. NuGet vulnerability-feed warnings were emitted because `api.nuget.org` was unavailable, but compilation and tests succeeded.