### PR TITLE
fix: accept leading map pipeline shorthand

### DIFF
--- a/Expressif.Testing/ExpressionTest.cs
+++ b/Expressif.Testing/ExpressionTest.cs
@@ -303,6 +303,14 @@ public class ExpressionTest
     }
 
     [Test]
+    public void Evaluate_LeadingMapPipeline_UsesImplicitInput()
+    {
+        var result = new Expression("|> add(1)").Evaluate(new object?[] { 10, 20 });
+
+        Assert.That(result, Is.EqualTo(new object?[] { 11m, 21m }));
+    }
+
+    [Test]
     public void Evaluate_StringArrayPipeMapUpper_Valid()
     {
         var expression = new ClosedExpression("{\"alice\",\"bob\"} | map(upper)");

--- a/Expressif.Testing/Parsers/ExpressionTest.cs
+++ b/Expressif.Testing/Parsers/ExpressionTest.cs
@@ -75,6 +75,24 @@ public class ExpressionTest
         });
     }
 
+    [Test]
+    public void Parse_LeadingMapPipeline_LowersEntirePipelineToMapFunction()
+    {
+        var root = RootExpression.Parser.Parse("|> add(1) | sum");
+
+        Assert.That(root, Is.TypeOf<OpenRootExpression>());
+        var expression = ((OpenRootExpression)root).Expression;
+        var map = expression.Members.Single();
+        var mappedExpression = ((OpenExpressionParameter)map.Parameters.Single()).Expression;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(map.Name, Is.EqualTo("map"));
+            Assert.That(map.Syntax, Is.EqualTo(FunctionSyntax.MapShorthand));
+            Assert.That(mappedExpression.Members.Select(x => x.Name), Is.EqualTo(new[] { "add", "sum" }));
+        });
+    }
+
     [TestCase("{1,2,3} |> absolute")]
     [TestCase("{1,2,3} |> ()")]
     [TestCase("{1,2,3} |> (absolute")]

--- a/Expressif/Parsers/RootExpression.cs
+++ b/Expressif/Parsers/RootExpression.cs
@@ -11,12 +11,22 @@ public record class ClosedRootExpression(ClosedExpression Expression) : IRootExp
 
 public static class RootExpression
 {
+    private static readonly Parser<IRootExpression> LeadingMapPipelineParser =
+        from _ in Parse.String("|>").Token()
+        from expression in OpenExpression.Parser
+        let map = new Function(
+            "map",
+            [new OpenExpressionParameter(expression)],
+            FunctionSyntax.MapShorthand)
+        select (IRootExpression)new OpenRootExpression(new OpenExpression([map]));
+
     private static readonly Parser<IRootExpression> TupleLiteralParser =
         from tuple in Parameter.TupleLiteralParser
         select (IRootExpression)new ClosedRootExpression(new ClosedExpression(tuple, []));
 
     public static readonly Parser<IRootExpression> Parser =
-        TupleLiteralParser
+        LeadingMapPipelineParser
+        .Or(TupleLiteralParser)
         .Or(OpenExpression.Parser.Select(x => (IRootExpression)new OpenRootExpression(x)))
         .Or(ClosedExpression.Parser.Select(x => (IRootExpression)new ClosedRootExpression(x)))
         .End();


### PR DESCRIPTION
## Summary

- accept a leading `|>` when an expression receives its source from implicit input
- lower the complete following pipeline into the map transformation
- add parser-shape and runtime regression coverage

## Root cause

The map-pipeline shorthand was only registered as a continuation parser, so it required an explicit expression on its left. A leading shorthand therefore failed before implicit input could be supplied by `evaluate`.

## Impact

Expressions such as `|> add(1) | sum` now parse as `map(add(1) | sum)`, preserving the intended pipeline boundary.

Fixes #512.

## Validation

- `dotnet test Expressif.Testing/Expressif.Testing.csproj --nologo --no-restore --maxcpucount:1 -p:UseSharedCompilation=false -nodeReuse:false`
- .NET 8, 9, and 10: 2,781 passed and 1 skipped per target