### PR TITLE
fix: Top-level CLI description now mention run command

### DIFF
--- a/Expressif.Cli/CliRootCommandFactory.cs
+++ b/Expressif.Cli/CliRootCommandFactory.cs
@@ -7,7 +7,7 @@ internal static class CliRootCommandFactory
 {
     public static RootCommand Create()
     {
-        var rootCommand = new RootCommand("Evaluate and validate Expressif expressions.");
+        var rootCommand = new RootCommand("Evaluate, run and validate Expressif expressions.");
 
         rootCommand.Subcommands.Add(EvaluateCommand.Create());
         rootCommand.Subcommands.Add(RunCommand.Create());


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the CLI help description to mention that expressions can be run, evaluated, and validated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->