### PR TITLE
fix: allow predicates in map

### DIFF
--- a/Expressif.Testing/ExpressionTest.cs
+++ b/Expressif.Testing/ExpressionTest.cs
@@ -320,6 +320,15 @@ public class ExpressionTest
     }
 
     [Test]
+    public void Evaluate_ArrayPipeMapPredicate_Valid()
+    {
+        var expression = new ClosedExpression("{10,15} | map(even)");
+        var result = expression.Evaluate();
+
+        Assert.That(result, Is.EqualTo(new object?[] { true, false }));
+    }
+
+    [Test]
     public void Evaluate_Map_PreservesCardinality()
     {
         var expression = new ClosedExpression("{1,2,3,4} | map(add(1))");

--- a/Expressif.Testing/Functions/FunctionTypeMapperTest.cs
+++ b/Expressif.Testing/Functions/FunctionTypeMapperTest.cs
@@ -47,4 +47,17 @@ public class PredicateTypeMapperTest
     [TestCase("foo - to - bar")]
     public void Execute_FunctionName_Invalid(string value)
         => Assert.That(() => new FunctionTypeMapper().Execute(value), Throws.TypeOf<NotImplementedFunctionException>());
+
+    [Test]
+    public void TryExecute_FunctionName_ReturnsWhetherFunctionExists()
+    {
+        var mapper = new FunctionTypeMapper();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(mapper.TryExecute("ceiling", out var type), Is.True);
+            Assert.That(type, Is.EqualTo(typeof(Ceiling)));
+            Assert.That(mapper.TryExecute("foo", out _), Is.False);
+        });
+    }
 }

--- a/Expressif.Testing/Parsers/FunctionTest.cs
+++ b/Expressif.Testing/Parsers/FunctionTest.cs
@@ -63,6 +63,16 @@ public class FunctionTest
     }
 
     [Test]
+    public void Parse_Function_MapWithPredicateParameter_Valid()
+    {
+        var function = Expressif.Parsers.Function.Parser.End().Parse("map(even)");
+
+        Assert.That(function.Parameters, Has.Length.EqualTo(1));
+        Assert.That(function.Parameters[0], Is.TypeOf<OpenExpressionParameter>());
+        Assert.That(((OpenExpressionParameter)function.Parameters[0]).Expression.Members.Single().Name, Is.EqualTo("even"));
+    }
+
+    [Test]
     public void Parse_Function_FilterWithOpenExpressionParameter_Valid()
     {
         var function = Expressif.Parsers.Function.Parser.Parse("filter(greater-than(2))");

--- a/Expressif/Functions/BaseTypeMapper.cs
+++ b/Expressif/Functions/BaseTypeMapper.cs
@@ -13,11 +13,23 @@ public abstract class BaseTypeMapper
 
     public Type Execute(string functionName)
     {
-        var name = functionName.ToKebabCase();
-        name = name.Replace("date-time", "dateTime");
-        if (!Mapping.TryGetValue(name, out var value))
+        if (!TryExecute(functionName, out var value))
             throw new NotImplementedFunctionException(functionName);
         return value;
+    }
+
+    public bool TryExecute(string functionName, out Type type)
+    {
+        var name = functionName.ToKebabCase();
+        name = name.Replace("date-time", "dateTime");
+        if (Mapping.TryGetValue(name, out var value))
+        {
+            type = value;
+            return true;
+        }
+
+        type = null!;
+        return false;
     }
 
     protected abstract IDictionary<string, Type> Initialize();

--- a/Expressif/Functions/ExpressionFactory.cs
+++ b/Expressif/Functions/ExpressionFactory.cs
@@ -17,6 +17,7 @@ namespace Expressif.Functions;
 public class ExpressionFactory : BaseExpressionFactory
 {
     private Parser<IRootExpression> Parser { get; } = RootExpression.Parser;
+    private static readonly PredicateTypeMapper PredicateTypeMapper = new();
     private static readonly HashSet<string> ImplicitFoldAccumulators = new(
         new AccumulatorIntrospector().Locate().Select(x => x.Name),
         StringComparer.OrdinalIgnoreCase
@@ -338,7 +339,15 @@ public class ExpressionFactory : BaseExpressionFactory
     }
 
     private Func<IFunction> BuildTransformationProvider(OpenExpressionParameter parameter, IContext context)
-        => () => new ChainFunction(parameter.Expression.Members.Select(member => InstantiateOrWrapAggregation(member, context)).ToArray());
+        => () => new ChainFunction(parameter.Expression.Members.Select(member => InstantiateTransformationMember(member, context)).ToArray());
+
+    private IFunction InstantiateTransformationMember(Parsers.Function member, IContext context)
+    {
+        if (!TypeMapper.TryExecute(member.Name, out _) && PredicateTypeMapper.TryExecute(member.Name, out _))
+            return new PredicationFactory().Instantiate(new SinglePredication(member), context);
+
+        return InstantiateOrWrapAggregation(member, context);
+    }
 
     private bool TryInstantiateWithPredicateProvider(Type type, Parsers.Function function, IContext context, out IFunction filtering)
     {


### PR DESCRIPTION
## Summary

- allow `map` transformation members to resolve predicates as evaluable expressions
- add non-throwing `TryExecute` lookup to type mappers while preserving function precedence
- add parser, mapper, and end-to-end regression coverage for `map(even)`

## Root cause

Map transformations were resolved exclusively through the function type mapper. Predicates implement the evaluable function contract, but names such as `even` only exist in the predicate mapper, so transformation construction failed after parsing.

## Validation

- Full `Expressif.Testing` suite on .NET 8, .NET 9, and .NET 10: 2,782 passed and 1 skipped per framework
- CLI reproduction: `expressif evaluate "map(even)" -i "{10,15}"` returns `{true, false}`
- `git diff --check`

Fixes #511