### PR TITLE
fix(parser): support nested expression parameters

### DIFF
--- a/Expressif.Testing/Functions/Special/SpecialFunctionsTest.cs
+++ b/Expressif.Testing/Functions/Special/SpecialFunctionsTest.cs
@@ -82,6 +82,23 @@ public class SpecialFunctionsTest
     }
 
     [Test]
+    public void Coalesce_NestedExpressions_EvaluatesEachArgument()
+    {
+        var value = new Dictionary<string, object?>
+        {
+            ["nickname"] = null,
+            ["name"] = "Alice"
+        };
+        var context = new Context();
+        context.CurrentObject.Set(value);
+        var function = new ExpressionFactory().Instantiate(
+            "coalesce(field(nickname), .name)",
+            context);
+
+        Assert.That(function.Evaluate(value), Is.EqualTo("Alice"));
+    }
+
+    [Test]
     [TestCase("foo")]
     [TestCase("(any)")]
     [TestCase("(empty)")]

--- a/Expressif.Testing/Parsers/FunctionTest.cs
+++ b/Expressif.Testing/Parsers/FunctionTest.cs
@@ -73,16 +73,16 @@ public class FunctionTest
     }
 
     [Test]
-    public void Parse_Function_FilterWithOpenExpressionParameter_Valid()
+    public void Parse_Function_FilterWithExpressionParameter_Valid()
     {
         var function = Expressif.Parsers.Function.Parser.Parse("filter(greater-than(2))");
 
         Assert.That(function.Name, Is.EqualTo("filter"));
         Assert.That(function.Parameters, Has.Length.EqualTo(1));
-        Assert.That(function.Parameters[0], Is.TypeOf<PredicationParameter>());
+        Assert.That(function.Parameters[0], Is.TypeOf<OpenExpressionParameter>());
 
-        var parameter = (PredicationParameter)function.Parameters[0];
-        Assert.That(parameter.Predication, Is.TypeOf<SinglePredication>());
+        var parameter = (OpenExpressionParameter)function.Parameters[0];
+        Assert.That(parameter.Expression.Members.Single().Name, Is.EqualTo("greater-than"));
     }
 
     [Test]
@@ -150,6 +150,51 @@ public class FunctionTest
         Assert.That(members[1].Parameters, Has.Length.EqualTo(1));
         Assert.That(members[2].Name, Is.EqualTo("add"));
         Assert.That(members[2].Parameters.Length, Is.GreaterThanOrEqualTo(2));
+    }
+
+    [TestCase("some(less-than(5))")]
+    [TestCase("some(.active)")]
+    [TestCase("some(.age | less-than(18))")]
+    [TestCase("map(.name | upper)")]
+    public void Parse_Function_WithExpressionParameter_Valid(string value)
+    {
+        var function = Expressif.Parsers.Function.Parser.End().Parse(value);
+
+        Assert.That(function.Parameters, Has.Length.EqualTo(1));
+        Assert.That(function.Parameters[0], Is.TypeOf<OpenExpressionParameter>());
+    }
+
+    [Test]
+    public void Parse_Function_WithMultipleExpressionParameters_Valid()
+    {
+        var function = Expressif.Parsers.Function.Parser.End().Parse(
+            "coalesce(.nickname, field(name), .display-name | upper)");
+
+        Assert.That(function.Parameters, Has.Length.EqualTo(3));
+        Assert.That(function.Parameters, Has.All.TypeOf<OpenExpressionParameter>());
+    }
+
+    [Test]
+    public void Parse_Function_WithNestedLongFormExpressionParameters_Valid()
+    {
+        var function = Expressif.Parsers.Function.Parser.End().Parse(
+            "coalesce(field(nickname), field(name))");
+
+        var expressions = function.Parameters.Cast<OpenExpressionParameter>().ToArray();
+        Assert.That(expressions, Has.Length.EqualTo(2));
+        Assert.That(expressions.Select(x => x.Expression.Members.Single().Name),
+            Is.EqualTo(new[] { "field", "field" }));
+    }
+
+    [TestCase("value", typeof(LiteralParameter))]
+    [TestCase("\"name\"", typeof(LiteralParameter))]
+    [TestCase("@foo", typeof(VariableParameter))]
+    [TestCase("[name]", typeof(ObjectPropertyParameter))]
+    public void Parse_Function_WithScalarParameter_PreservesParameterType(string value, Type expectedType)
+    {
+        var function = Expressif.Parsers.Function.Parser.End().Parse($"example({value})");
+
+        Assert.That(function.Parameters.Single(), Is.TypeOf(expectedType));
     }
 
     [Test]

--- a/Expressif/Functions/ExpressionFactory.cs
+++ b/Expressif/Functions/ExpressionFactory.cs
@@ -132,7 +132,7 @@ public class ExpressionFactory : BaseExpressionFactory
     
     private IFunction BuildAdjacentFunction(Parsers.Function function, IContext context)
     {
-        if (function.Parameters.Length != 1 || function.Parameters[0] is not OpenExpressionParameter open)
+        if (function.Parameters.Length != 1 || !TryGetOpenExpression(function.Parameters[0], out var open))
             throw new MissingOrUnexpectedParametersFunctionException(function.Name, function.Parameters.Length);
 
         var members = open.Expression.Members.ToArray();
@@ -329,7 +329,7 @@ public class ExpressionFactory : BaseExpressionFactory
         if (function.Parameters.Length != 1)
             throw new MissingOrUnexpectedParametersFunctionException(function.Name, function.Parameters.Length);
 
-        if (function.Parameters[0] is not OpenExpressionParameter openExpression)
+        if (!TryGetOpenExpression(function.Parameters[0], out var openExpression))
             throw new ArgumentException(
                 $"The function named '{function.Name}' expects a parameter of type '{nameof(OpenExpressionParameter)}' but received '{function.Parameters[0].GetType().Name}'.",
                 nameof(function));
@@ -362,7 +362,7 @@ public class ExpressionFactory : BaseExpressionFactory
         if (function.Parameters.Length != 1)
             throw new MissingOrUnexpectedParametersFunctionException(function.Name, function.Parameters.Length);
 
-        if (function.Parameters[0] is not PredicationParameter and not OpenExpressionParameter)
+        if (function.Parameters[0] is not PredicationParameter && !TryGetOpenExpression(function.Parameters[0], out _))
             throw new ArgumentException(
                 $"The function named '{function.Name}' expects a parameter of type '{nameof(PredicationParameter)}' or '{nameof(OpenExpressionParameter)}' but received '{function.Parameters[0].GetType().Name}'.",
                 nameof(function));
@@ -374,10 +374,12 @@ public class ExpressionFactory : BaseExpressionFactory
     private Func<IPredicate> BuildPredicateProvider(IParameter parameter, IContext context, string functionName)
     {
         var factory = new PredicationFactory();
+        if (TryGetOpenExpression(parameter, out var openExpression))
+            return BuildSinglePredicateFromOpenExpression(openExpression, factory, context, functionName);
+
         return parameter switch
         {
             PredicationParameter predication => () => factory.Instantiate(predication.Predication, context),
-            OpenExpressionParameter openExpression => BuildSinglePredicateFromOpenExpression(openExpression, factory, context, functionName),
             _ => throw new ArgumentException(
                     $"The function named '{functionName}' expects a parameter of type '{nameof(PredicationParameter)}' or '{nameof(OpenExpressionParameter)}' but received '{parameter.GetType().Name}'.",
                     nameof(parameter))
@@ -398,6 +400,18 @@ public class ExpressionFactory : BaseExpressionFactory
             var predication = new SinglePredication(members.Single());
             return () => factory.Instantiate(predication, context);
         }
+    }
+
+    private static bool TryGetOpenExpression(IParameter parameter, out OpenExpressionParameter expression)
+    {
+        expression = parameter switch
+        {
+            OpenExpressionParameter open => open,
+            LiteralParameter literal => new OpenExpressionParameter(
+                new OpenExpression([new Parsers.Function(literal.Value, [])])),
+            _ => null!
+        };
+        return expression is not null;
     }
 
     private sealed class BooleanExpressionPredicate(IFunction expression) : IPredicate

--- a/Expressif/Parsers/Function.cs
+++ b/Expressif/Parsers/Function.cs
@@ -10,22 +10,20 @@ public enum FunctionSyntax
 {
     Standard,
     MapShorthand,
-    FieldShorthand
+    FieldShorthand,
+    TupleProjectionShorthand
 }
 
 public class Function : IExpression
 {
-    private static readonly Parser<IParameter[]> OpenExpressionParametersParser =
+    // A bare token is structurally indistinguishable from a literal. Preserve the
+    // established map(function) shorthand while generic parameters handle every
+    // expression whose syntax is unambiguous.
+    private static readonly Parser<IParameter[]> MapParametersParser =
         from _ in Parse.Char('(').Token()
         from expression in OpenExpression.Parser.Token()
         from _1 in Parse.Char(')').Token()
         select new IParameter[] { new OpenExpressionParameter(expression) };
-
-    private static readonly Parser<IParameter[]> PredicationParametersParser =
-        from _ in Parse.Char('(').Token()
-        from predication in Predication.Parser.Token()
-        from _1 in Parse.Char(')').Token()
-        select new IParameter[] { new PredicationParameter(predication) };
 
     private static readonly Parser<IParameter[]> RecordParametersParser =
         from _ in Parse.Char('(').Token()
@@ -55,19 +53,12 @@ public class Function : IExpression
     private static readonly Parser<Function> TupleProjectionShorthandParser =
         from _ in Parse.Char('$')
         from index in Parse.Number
-        select new Function("tuple-at", [new LiteralParameter(index)]);
-
-    private static readonly Parser<IParameter[]> FieldShorthandParametersParser =
-        from function in FieldShorthandParser.Contained(Parse.Char('(').Token(), Parse.Char(')').Token())
-        select new IParameter[] { new OpenExpressionParameter(new OpenExpression([function])) };
+        select new Function("tuple-at", [new LiteralParameter(index)], FunctionSyntax.TupleProjectionShorthand);
 
     private static readonly Parser<Function> StandardParser =
         from functionName in Grammar.FunctionName
-        from parameters in (functionName.Equals("filter", StringComparison.OrdinalIgnoreCase)
-                                ? FieldShorthandParametersParser.Or(PredicationParametersParser).Optional()
-                                : functionName.Equals("map", StringComparison.OrdinalIgnoreCase)
-                                  || functionName.Equals("adjacent", StringComparison.OrdinalIgnoreCase)
-                                ? OpenExpressionParametersParser.Optional()
+        from parameters in (functionName.Equals("map", StringComparison.OrdinalIgnoreCase)
+                                ? MapParametersParser.Optional()
                                 : functionName.Equals("record", StringComparison.OrdinalIgnoreCase)
                                 ? RecordParametersParser.Optional()
                                 : Parsers.Parameters.Parser.Optional())

--- a/Expressif/Parsers/Parameter.cs
+++ b/Expressif/Parsers/Parameter.cs
@@ -71,6 +71,20 @@ public class Parameter
         from _1 in Parse.Char('}').Token()
         select new InputExpressionParameter(new ClosedExpression(parameter, expression.Members));
 
+    protected static readonly Parser<IParameter> PredicationParameter =
+        from predication in Parse.Ref(() => Predication.Parser)
+        where predication is not SinglePredication
+        select new PredicationParameter(predication);
+
+    protected static readonly Parser<IParameter> OpenExpressionParameter =
+        from expression in Parse.Ref(() => OpenExpression.Parser)
+        let members = expression.Members.ToArray()
+        where !members[0].Name.Equals("T", StringComparison.OrdinalIgnoreCase)
+            && (members.Length > 1
+                || members.Any(x => x.Syntax == FunctionSyntax.FieldShorthand
+                    || x.Syntax == FunctionSyntax.Standard && x.Parameters.Length > 0))
+        select new OpenExpressionParameter(expression);
+
     protected static readonly Parser<IParameter> ArrayLiteralParameter =
         from _ in Parse.Char('{').Token()
         from values in (
@@ -173,13 +187,15 @@ public class Parameter
     public static readonly Parser<IParameter> Parser = 
         VariableParameter
         .Or(IntervalParameter)
-        .Or(TupleProjectionParameter)
         .Or(IndexParameter)
         .Or(ItemParameter)
         .Or(TupleLiteralParser)
         .Or(RecordLiteralParameter)
         .Or(ArrayLiteralParameter)
         .Or(ParametrizedExpressionParameter)
+        .Or(PredicationParameter)
+        .Or(OpenExpressionParameter)
+        .Or(TupleProjectionParameter)
         .Or(LiteralParameter)
         ;
 }

--- a/Expressif/Parsers/Parameter.cs
+++ b/Expressif/Parsers/Parameter.cs
@@ -1,4 +1,4 @@
-﻿using Expressif.Values;
+using Expressif.Values;
 using Sprache;
 using System;
 using System.Collections.Generic;
@@ -82,7 +82,7 @@ public class Parameter
         where !members[0].Name.Equals("T", StringComparison.OrdinalIgnoreCase)
             && (members.Length > 1
                 || members.Any(x => x.Syntax == FunctionSyntax.FieldShorthand
-                    || x.Syntax == FunctionSyntax.Standard && x.Parameters.Length > 0))
+                    || (x.Syntax == FunctionSyntax.Standard && x.Parameters.Length > 0)))
         select new OpenExpressionParameter(expression);
 
     protected static readonly Parser<IParameter> ArrayLiteralParameter =


### PR DESCRIPTION
## Summary

- parse structurally recognizable nested expressions as generic function parameters
- terminate nested arguments at commas and matching parentheses while preserving scalar parameter types
- preserve ambiguous bare `map(function)` syntax and bind bare transformation/predicate tokens compatibly
- add parser coverage for nested calls, field shorthand, pipelines, multiple arguments, and scalar parameters
- add end-to-end coverage for nested `coalesce` expressions

## Root cause

The generic parameter grammar only represented scalar values. Expression-taking functions bypassed it through function-name-specific parsers, so nested calls supplied to other functions stopped at the inner closing parenthesis.

## Validation

- Full `Expressif.Testing` suite on .NET 10: 2,851 passed, 1 skipped
- `FunctionTest` on .NET 8, .NET 9, and .NET 10: 36 passed per framework

Close #541

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Function expressions now support nested and multiple expression parameters.
  - Literal values can be used wherever open expressions are accepted.
  - Tuple projection shorthand syntax is now supported.

- **Bug Fixes**
  - Improved parsing and evaluation for `filter`, `map`, `adjacent`, and predicate-based functions.
  - Scalar parameter types are preserved during parsing.
  - `coalesce` correctly evaluates nested expressions and returns the first non-null result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->