### PR TITLE
fix(cli): parse evaluate inputs as typed values

### DIFF
--- a/Expressif.Cli.Tests/CliCommandTests.cs
+++ b/Expressif.Cli.Tests/CliCommandTests.cs
@@ -11,9 +11,7 @@ public class CliCommandTests
     [TearDown]
     public void TearDown()
     {
-        EvaluateCommand.BuildExpression = static (code, context) => new Expression(code, context);
-        EvaluateCommand.BuildClosedExpression = static (code, context) => new ClosedExpression(code, context);
-        EvaluateCommand.EvaluateClosedExpression = static expression => expression.Evaluate();
+        EvaluateCommand.ResetDelegates();
         RunCommand.ResetDelegates();
         ValidateCommand.BuildExpression = static (code, context) => new Expression(code, context);
         ValidateCommand.BuildClosedExpression = static (code, context) => new ClosedExpression(code, context);
@@ -67,7 +65,7 @@ public class CliCommandTests
     }
 
     [Test]
-    public async Task Evaluate_ImplicitSum_WithStringArrayLiteralInput_ReturnsAggregatedResult()
+    public async Task Evaluate_ArrayLiteralInput_ReturnsAggregatedResult()
     {
         var result = await InvokeAsync("evaluate", "sum", "--input", "{1,2,2}");
 
@@ -75,6 +73,32 @@ public class CliCommandTests
         {
             Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.Success));
             Assert.That(result.StdOut.Trim(), Is.EqualTo("5"));
+            Assert.That(result.StdErr, Is.Empty);
+        });
+    }
+
+    [Test]
+    public async Task Evaluate_RecordLiteralInput_ReturnsFieldValue()
+    {
+        var result = await InvokeAsync("evaluate", ".loc", "--input", "{loc:=mons, temp:=17.5}");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.Success));
+            Assert.That(result.StdOut.Trim(), Is.EqualTo("mons"));
+            Assert.That(result.StdErr, Is.Empty);
+        });
+    }
+
+    [Test]
+    public async Task Evaluate_TupleLiteralInput_ReturnsTupleField()
+    {
+        var result = await InvokeAsync("evaluate", "tuple-second", "--input", "T(mons, 17.5)");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.ExitCode, Is.EqualTo(ExitCodes.Success));
+            Assert.That(result.StdOut.Trim(), Is.EqualTo("17.5"));
             Assert.That(result.StdErr, Is.Empty);
         });
     }

--- a/Expressif.Cli/Commands/EvaluateCommand.cs
+++ b/Expressif.Cli/Commands/EvaluateCommand.cs
@@ -122,7 +122,7 @@ internal static class EvaluateCommand
         }
 
         return hasInputOption
-            ? EvaluateOpen(expressionCode, parseResult.GetValue(inputOption), hasExpressionFile, expressionFilePath)
+            ? EvaluateInput(expressionCode, parseResult.GetValue(inputOption), hasExpressionFile, expressionFilePath)
             : EvaluateClosed(expressionCode, hasExpressionFile, expressionFilePath);
     }
 
@@ -218,6 +218,26 @@ internal static class EvaluateCommand
         }
     }
 
+    private static int EvaluateInput(
+        string expressionCode,
+        string? input,
+        bool hasExpressionFile,
+        string? expressionFilePath)
+    {
+        object? parsedInput;
+        try
+        {
+            parsedInput = ParseInput(input ?? string.Empty);
+        }
+        catch (FormatException exception)
+        {
+            Console.Error.WriteLine($"Invalid input syntax for --input '{input}': {exception.Message}");
+            return ExitCodes.InvalidExpressionOrInput;
+        }
+
+        return EvaluateOpen(expressionCode, parsedInput, hasExpressionFile, expressionFilePath);
+    }
+
     private static int ValidateAsOpenExpression(string expressionCode, bool hasExpressionFile, string? expressionFilePath)
     {
         try
@@ -257,20 +277,9 @@ internal static class EvaluateCommand
                 return ExitCodes.UnexpectedInternalError;
             }
 
-            object? parsedInput;
             try
             {
-                parsedInput = ParseInput(input ?? string.Empty);
-            }
-            catch (FormatException exception)
-            {
-                Console.Error.WriteLine($"Invalid input syntax for --input '{input}': {exception.Message}");
-                return ExitCodes.InvalidExpressionOrInput;
-            }
-
-            try
-            {
-                var result = openExpression.Evaluate(parsedInput);
+                var result = openExpression.Evaluate(input);
                 Console.Out.WriteLine(ValueFormatter.Format(result));
                 return ExitCodes.Success;
             }

--- a/Expressif.Cli/Commands/EvaluateCommand.cs
+++ b/Expressif.Cli/Commands/EvaluateCommand.cs
@@ -5,6 +5,8 @@ namespace Expressif.Cli.Commands;
 
 internal static class EvaluateCommand
 {
+    private static readonly Func<string, object?> DefaultParseInput = static input => RunCommand.InputValueParser.Parse(input);
+
     internal static Func<string, Context, Expression> BuildExpression { get; set; }
         = static (code, context) => new Expression(code, context);
 
@@ -13,6 +15,17 @@ internal static class EvaluateCommand
 
     internal static Func<ClosedExpression, object?> EvaluateClosedExpression { get; set; }
         = static expression => expression.Evaluate();
+
+    internal static Func<string, object?> ParseInput { get; set; }
+        = DefaultParseInput;
+
+    internal static void ResetDelegates()
+    {
+        BuildExpression = static (code, context) => new Expression(code, context);
+        BuildClosedExpression = static (code, context) => new ClosedExpression(code, context);
+        EvaluateClosedExpression = static expression => expression.Evaluate();
+        ParseInput = DefaultParseInput;
+    }
 
     public static Command Create()
     {
@@ -244,9 +257,20 @@ internal static class EvaluateCommand
                 return ExitCodes.UnexpectedInternalError;
             }
 
+            object? parsedInput;
             try
             {
-                var result = openExpression.Evaluate(input);
+                parsedInput = ParseInput(input ?? string.Empty);
+            }
+            catch (FormatException exception)
+            {
+                Console.Error.WriteLine($"Invalid input syntax for --input '{input}': {exception.Message}");
+                return ExitCodes.InvalidExpressionOrInput;
+            }
+
+            try
+            {
+                var result = openExpression.Evaluate(parsedInput);
                 Console.Out.WriteLine(ValueFormatter.Format(result));
                 return ExitCodes.Success;
             }

--- a/Expressif.Cli/Commands/RunCommand.cs
+++ b/Expressif.Cli/Commands/RunCommand.cs
@@ -840,6 +840,7 @@ internal static class RunCommand
                     : literal.Value,
                 QuotedLiteralParameter quoted => quoted.Value,
                 ArrayParameter array => array.Values.Select(ConvertToRuntimeValue).ToArray(),
+                TupleParameter tuple => new Expressif.Values.Tuple(tuple.Values.Select(ConvertToRuntimeValue).ToArray()),
                 RecordLiteralParameter record => ConvertRecord(record),
                 _ => ParameterSerializer.Serialize(parameter),
             };


### PR DESCRIPTION
## Summary

- parse `evaluate --input` through the same `InputValueParser` path used by `run`
- materialize tuple literals as typed tuple values in the shared parser
- add regression coverage for array, record, and tuple inputs

## Root cause

`evaluate` forwarded the raw command-line string directly to `Expression.Evaluate(...)`, while `run` parsed input literals first. Structured inputs therefore reached the two commands with different runtime types.

## Validation

- `Evaluate_ArrayLiteralInput_ReturnsAggregatedResult`
- `Evaluate_RecordLiteralInput_ReturnsFieldValue`
- `Evaluate_TupleLiteralInput_ReturnsTupleField`

All three focused regression tests pass. The full CLI suite currently reports 82 passed and one unrelated pre-existing failure in `Run_InputRecordWithDuplicateFields_ReturnsClearError`.

Closes #538