### PR TITLE
fix(special): treat missing coalesce fields as null

### DIFF
--- a/Expressif.Testing/Functions/Special/SpecialFunctionsTest.cs
+++ b/Expressif.Testing/Functions/Special/SpecialFunctionsTest.cs
@@ -98,6 +98,37 @@ public class SpecialFunctionsTest
         Assert.That(function.Evaluate(value), Is.EqualTo("Alice"));
     }
 
+    [TestCase("coalesce(.nickname, .name)", "Alice")]
+    [TestCase("coalesce(field(nickname), field(name))", "Alice")]
+    [TestCase("coalesce(.nickname, field(name))", "Alice")]
+    [TestCase("coalesce(.nickname | upper, .name | upper)", "ALICE")]
+    [TestCase("coalesce(.nickname, .display-name, .name)", "Alice")]
+    [TestCase("coalesce(.nickname, .display-name)", null)]
+    public void Coalesce_MissingField_ContinuesWithNextCandidate(string expression, object? expected)
+    {
+        var value = new Dictionary<string, object?> { ["name"] = "Alice" };
+        var context = new Context();
+        context.CurrentObject.Set(value);
+        var function = new ExpressionFactory().Instantiate(expression, context);
+
+        Assert.That(function.Evaluate(value), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void Coalesce_ExplicitNullField_ContinuesWithNextCandidate()
+    {
+        var value = new Dictionary<string, object?>
+        {
+            ["nickname"] = null,
+            ["name"] = "Alice"
+        };
+        var context = new Context();
+        context.CurrentObject.Set(value);
+        var function = new ExpressionFactory().Instantiate("coalesce(.nickname, .name)", context);
+
+        Assert.That(function.Evaluate(value), Is.EqualTo("Alice"));
+    }
+
     [Test]
     [TestCase("foo")]
     [TestCase("(any)")]

--- a/Expressif.Testing/Functions/Special/SpecialFunctionsTest.cs
+++ b/Expressif.Testing/Functions/Special/SpecialFunctionsTest.cs
@@ -100,6 +100,7 @@ public class SpecialFunctionsTest
 
     [TestCase("coalesce(.nickname, .name)", "Alice")]
     [TestCase("coalesce(field(nickname), field(name))", "Alice")]
+    [TestCase("coalesce(field(\"nickname\"), field(\"name\"))", "Alice")]
     [TestCase("coalesce(.nickname, field(name))", "Alice")]
     [TestCase("coalesce(.nickname | upper, .name | upper)", "ALICE")]
     [TestCase("coalesce(.nickname, .display-name, .name)", "Alice")]

--- a/Expressif/Functions/ExpressionFactory.cs
+++ b/Expressif/Functions/ExpressionFactory.cs
@@ -124,10 +124,32 @@ public class ExpressionFactory : BaseExpressionFactory
             return input => input;
 
         if (parameter is OpenExpressionParameter open)
-            return BuildOpenExpressionRecordEvaluator(open, context);
+            return TryBuildCoalesceFieldEvaluator(open, context, out var evaluator)
+                ? evaluator
+                : BuildOpenExpressionRecordEvaluator(open, context);
 
         var provider = CreateParameter(parameter, typeof(object), context);
         return _ => provider.DynamicInvoke();
+    }
+
+    private bool TryBuildCoalesceFieldEvaluator(
+        OpenExpressionParameter open,
+        IContext context,
+        out Func<object?, object?> evaluator)
+    {
+        evaluator = null!;
+        var members = open.Expression.Members.ToArray();
+        if (members.Length == 0
+            || !members[0].Name.Equals("field", StringComparison.OrdinalIgnoreCase)
+            || members[0].Parameters is not [LiteralParameter fieldName])
+            return false;
+
+        var remainder = new ChainFunction(
+            members.Skip(1).Select(member => InstantiateOrWrapAggregation(member, context)).ToArray());
+        evaluator = input => NamedValueAccessor.TryGetValue(input, fieldName.Value, out var fieldValue)
+            ? remainder.Evaluate(fieldValue)
+            : null;
+        return true;
     }
     
     private IFunction BuildAdjacentFunction(Parsers.Function function, IContext context)

--- a/Expressif/Functions/ExpressionFactory.cs
+++ b/Expressif/Functions/ExpressionFactory.cs
@@ -141,15 +141,26 @@ public class ExpressionFactory : BaseExpressionFactory
         var members = open.Expression.Members.ToArray();
         if (members.Length == 0
             || !members[0].Name.Equals("field", StringComparison.OrdinalIgnoreCase)
-            || members[0].Parameters is not [LiteralParameter fieldName])
+            || !TryGetFieldName(members[0].Parameters, out var fieldName))
             return false;
 
         var remainder = new ChainFunction(
             members.Skip(1).Select(member => InstantiateOrWrapAggregation(member, context)).ToArray());
-        evaluator = input => NamedValueAccessor.TryGetValue(input, fieldName.Value, out var fieldValue)
+        evaluator = input => NamedValueAccessor.TryGetValue(input, fieldName, out var fieldValue)
             ? remainder.Evaluate(fieldValue)
             : null;
         return true;
+    }
+
+    private static bool TryGetFieldName(IParameter[] parameters, out string fieldName)
+    {
+        fieldName = parameters switch
+        {
+            [LiteralParameter literal] => literal.Value,
+            [QuotedLiteralParameter quoted] => quoted.Value,
+            _ => string.Empty
+        };
+        return parameters is [LiteralParameter] or [QuotedLiteralParameter];
     }
     
     private IFunction BuildAdjacentFunction(Parsers.Function function, IContext context)


### PR DESCRIPTION
## Summary

- treat a missing leading `field(...)` lookup as a null `coalesce` candidate
- continue evaluating the remaining candidates from the same original input
- preserve standalone field-access errors and avoid swallowing unrelated pipeline failures
- cover shorthand, long-form, mixed, pipelined, multi-candidate, all-missing, and explicit-null cases

## Root cause

`coalesce` compiled each open-expression candidate as a normal function chain. A leading field lookup therefore used the throwing field accessor, so an absent field aborted evaluation before `coalesce` could advance to the next candidate.

## Validation

- `dotnet test Expressif.Testing/Expressif.Testing.csproj --framework net10.0 --no-restore --disable-build-servers --nologo --verbosity minimal --maxcpucount:1 -p:UseSharedCompilation=false`
- 2,858 passed, 1 skipped
- `git diff --check`

Close #544

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `coalesce` handling for missing fields and explicit null values.
  * `coalesce` now correctly continues to the next candidate when a field is unavailable.
  * Added support for mixed field expressions and chained pipelines within `coalesce`.
  * When all candidates are missing, `coalesce` now consistently returns null.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->