### PR TITLE
fix(parser): delimit map shorthand expressions

### DIFF
--- a/Expressif.Testing/ExpressionTest.cs
+++ b/Expressif.Testing/ExpressionTest.cs
@@ -302,12 +302,39 @@ public class ExpressionTest
         Assert.That(result, Is.EqualTo(new object?[] { 8m, 7m, 6m }));
     }
 
+    [TestCase("{1,12,5,42,17} |> add(1) | sum")]
+    [TestCase("{1,12,5,42,17} |> (add(1)) | sum")]
+    public void Evaluate_ArrayMapShorthand_ResumesParentPipeline(string code)
+    {
+        var result = new ClosedExpression(code).Evaluate();
+
+        Assert.That(result, Is.EqualTo(82m));
+    }
+
     [Test]
     public void Evaluate_LeadingMapPipeline_UsesImplicitInput()
     {
         var result = new Expression("|> add(1)").Evaluate(new object?[] { 10, 20 });
 
         Assert.That(result, Is.EqualTo(new object?[] { 11m, 21m }));
+    }
+
+    [TestCase("|> add(1) | sum")]
+    [TestCase("|> (add(1)) | sum")]
+    public void Evaluate_LeadingMapShorthand_ResumesParentPipeline(string code)
+    {
+        var result = new Expression(code).Evaluate(new object?[] { 1, 12, 5, 42, 17 });
+
+        Assert.That(result, Is.EqualTo(82m));
+    }
+
+    [Test]
+    public void Evaluate_ParenthesizedMapShorthand_ContainsInnerPipeline()
+    {
+        var result = new Expression("|> (absolute | add(1)) | sum")
+            .Evaluate(new object?[] { -1, 12, -5, 42, -17 });
+
+        Assert.That(result, Is.EqualTo(82m));
     }
 
     [Test]

--- a/Expressif.Testing/Parsers/ExpressionTest.cs
+++ b/Expressif.Testing/Parsers/ExpressionTest.cs
@@ -76,26 +76,46 @@ public class ExpressionTest
     }
 
     [Test]
-    public void Parse_LeadingMapPipeline_LowersEntirePipelineToMapFunction()
+    [TestCase("|> add(1) | sum", new[] { "add" })]
+    [TestCase("|> (add(1)) | sum", new[] { "add" })]
+    [TestCase("|> (absolute | add(1)) | sum", new[] { "absolute", "add" })]
+    public void Parse_LeadingMapPipeline_ResumesParentPipelineAfterMappedExpression(
+        string value, string[] expectedMappedFunctions)
     {
-        var root = RootExpression.Parser.Parse("|> add(1) | sum");
+        var root = RootExpression.Parser.Parse(value);
 
         Assert.That(root, Is.TypeOf<OpenRootExpression>());
         var expression = ((OpenRootExpression)root).Expression;
-        var map = expression.Members.Single();
+        var map = expression.Members.First();
         var mappedExpression = ((OpenExpressionParameter)map.Parameters.Single()).Expression;
 
         Assert.Multiple(() =>
         {
+            Assert.That(expression.Members.Select(x => x.Name), Is.EqualTo(new[] { "map", "sum" }));
             Assert.That(map.Name, Is.EqualTo("map"));
             Assert.That(map.Syntax, Is.EqualTo(FunctionSyntax.MapShorthand));
-            Assert.That(mappedExpression.Members.Select(x => x.Name), Is.EqualTo(new[] { "add", "sum" }));
+            Assert.That(mappedExpression.Members.Select(x => x.Name), Is.EqualTo(expectedMappedFunctions));
         });
     }
 
-    [TestCase("{1,2,3} |> absolute")]
     [TestCase("{1,2,3} |> ()")]
     [TestCase("{1,2,3} |> (absolute")]
-    public void Parse_MapShorthandWithoutParenthesizedExpression_Invalid(string value)
+    public void Parse_MapShorthandWithInvalidExpression_Invalid(string value)
         => Assert.That(() => Expressif.Parsers.ClosedExpression.Parser.End().Parse(value), Throws.TypeOf<ParseException>());
+
+    [Test]
+    public void Parse_UnparenthesizedMapShorthand_ConsumesSingleFunction()
+    {
+        var expression = Expressif.Parsers.ClosedExpression.Parser.End()
+            .Parse("{1,2,3} |> absolute | add(1) | sum");
+
+        var map = expression.Members.First();
+        var mappedExpression = ((OpenExpressionParameter)map.Parameters.Single()).Expression;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(expression.Members.Select(x => x.Name), Is.EqualTo(new[] { "map", "add", "sum" }));
+            Assert.That(mappedExpression.Members.Select(x => x.Name), Is.EqualTo(new[] { "absolute" }));
+        });
+    }
 }

--- a/Expressif/Parsers/Expression.cs
+++ b/Expressif/Parsers/Expression.cs
@@ -15,9 +15,11 @@ public class OpenExpression : IExpression
     public OpenExpression(IEnumerable<Function> members)
         => (Members) = (members);
 
-    private static readonly Parser<Function> MapShorthandParser =
+    internal static readonly Parser<Function> MapShorthandParser =
         from _ in Parse.String("|>").Token()
-        from expression in Parse.Ref(() => Parser).Contained(Parse.Char('(').Token(), Parse.Char(')').Token())
+        from expression in Parse.Ref(() => Parser)
+            .Contained(Parse.Char('(').Token(), Parse.Char(')').Token())
+            .Or(Function.Parser.Token().Select(function => new OpenExpression([function])))
         select new Function("map", [new OpenExpressionParameter(expression)], FunctionSyntax.MapShorthand);
 
     internal static readonly Parser<Function> ContinuationParser =

--- a/Expressif/Parsers/RootExpression.cs
+++ b/Expressif/Parsers/RootExpression.cs
@@ -12,13 +12,9 @@ public record class ClosedRootExpression(ClosedExpression Expression) : IRootExp
 public static class RootExpression
 {
     private static readonly Parser<IRootExpression> LeadingMapPipelineParser =
-        from _ in Parse.String("|>").Token()
-        from expression in OpenExpression.Parser
-        let map = new Function(
-            "map",
-            [new OpenExpressionParameter(expression)],
-            FunctionSyntax.MapShorthand)
-        select (IRootExpression)new OpenRootExpression(new OpenExpression([map]));
+        from map in OpenExpression.MapShorthandParser
+        from others in OpenExpression.ContinuationParser.Many()
+        select (IRootExpression)new OpenRootExpression(new OpenExpression([map, .. others]));
 
     private static readonly Parser<IRootExpression> TupleLiteralParser =
         from tuple in Parameter.TupleLiteralParser


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Map shorthand expressions now support parenthesized and single-function forms within pipelines.
  * Leading map expressions can continue into subsequent pipeline operations.
  * Nested mappings, including expressions such as `absolute | add(1)`, are supported.

* **Bug Fixes**
  * Corrected pipeline evaluation so mapped results flow into following operations as expected.
  * Improved parsing of map shorthand expressions and invalid forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->